### PR TITLE
Add Biome for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Biome CLI
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+
+      - name: Run Biome
+        run: biome ci .

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bannedFromRoles.json
 
 # Temporary files
 uploads/
+
+# AI Files
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ node index.js
 
 If the configuration is correct, the bot should appear online in Discord, and its slash commands will be registered/updated for the specified guild.
 
+## 🧹 Code Quality
+
+This project uses [Biome](https://biomejs.dev/) for consistent code style and quality:
+
+```bash
+npm run biome
+```
+
 ## 🚢 Deployment
 
 Simply create a new release in GitHub and the website will be automatically deployed to the server.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/commands/2xdps.js
+++ b/commands/2xdps.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("2xdps")
-        .setDescription("Info on the ruby-shop 2x damage"),
+	data: new SlashCommandBuilder()
+		.setName('2xdps')
+		.setDescription('Info on the ruby-shop 2x damage'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Double Damage is a purchasable 2x dps increase from the shop. Due to the exponential increase of the numbers in this game, it's fairly insignificant. Prioritize getting 4 autoclickers, after that buying 2x damage is fine but optional. 2x Damage does not apply to First Ascension New Transcendence (FANT)" })
-    }
+		await interaction.reply({
+			content:
+				"Double Damage is a purchasable 2x dps increase from the shop. Due to the exponential increase of the numbers in this game, it's fairly insignificant. Prioritize getting 4 autoclickers, after that buying 2x damage is fine but optional. 2x Damage does not apply to First Ascension New Transcendence (FANT)",
+		});
+	},
 };

--- a/commands/2xdps.js
+++ b/commands/2xdps.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on the ruby-shop 2x damage'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Double Damage is a purchasable 2x dps increase from the shop. Due to the exponential increase of the numbers in this game, it's fairly insignificant. Prioritize getting 4 autoclickers, after that buying 2x damage is fine but optional. 2x Damage does not apply to First Ascension New Transcendence (FANT)",

--- a/commands/666.js
+++ b/commands/666.js
@@ -1,13 +1,13 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("666")
-        .setDescription("For the glory of satan of course!"),
+	data: new SlashCommandBuilder()
+		.setName('666')
+		.setDescription('For the glory of satan of course!'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "For the glory of satan of course!" })
-    }
+		await interaction.reply({ content: 'For the glory of satan of course!' });
+	},
 };

--- a/commands/666.js
+++ b/commands/666.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('For the glory of satan of course!'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({ content: 'For the glory of satan of course!' });
 	},
 };

--- a/commands/Console AS.js
+++ b/commands/Console AS.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Console AS google sheet'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'**For console use only**\n<https://docs.google.com/spreadsheets/d/1m09HoNiLW-7t96gzguG9tU_HHaRrDrtMpAoAuukLB4w/edit#gid=0>',

--- a/commands/Console AS.js
+++ b/commands/Console AS.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("consoleas")
-        .setDescription("Console AS google sheet"),
+	data: new SlashCommandBuilder()
+		.setName('consoleas')
+		.setDescription('Console AS google sheet'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "**For console use only**\n<https://docs.google.com/spreadsheets/d/1m09HoNiLW-7t96gzguG9tU_HHaRrDrtMpAoAuukLB4w/edit#gid=0>" })
-    }
-}
+		await interaction.reply({
+			content:
+				'**For console use only**\n<https://docs.google.com/spreadsheets/d/1m09HoNiLW-7t96gzguG9tU_HHaRrDrtMpAoAuukLB4w/edit#gid=0>',
+		});
+	},
+};

--- a/commands/ConsoleHybrid.js
+++ b/commands/ConsoleHybrid.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('info on console hybrid play'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Console is a fun alternative to the current version of the game. Just note that because it's behind a few versions, it's slower to progress.\nActive is still better, but because you may want to rely on offline progress, Hybrid is better. You'll also want to level Xyl with reasonable balance each Transcension, so Siyalatas can be a more comparable alternative to Juggernaut.",

--- a/commands/ConsoleHybrid.js
+++ b/commands/ConsoleHybrid.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("consolehybrid")
-        .setDescription("info on console hybrid play"),
+	data: new SlashCommandBuilder()
+		.setName('consolehybrid')
+		.setDescription('info on console hybrid play'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Console is a fun alternative to the current version of the game. Just note that because it's behind a few versions, it's slower to progress.\nActive is still better, but because you may want to rely on offline progress, Hybrid is better. You'll also want to level Xyl with reasonable balance each Transcension, so Siyalatas can be a more comparable alternative to Juggernaut." })
-    }
-}
+		await interaction.reply({
+			content:
+				"Console is a fun alternative to the current version of the game. Just note that because it's behind a few versions, it's slower to progress.\nActive is still better, but because you may want to rely on offline progress, Hybrid is better. You'll also want to level Xyl with reasonable balance each Transcension, so Siyalatas can be a more comparable alternative to Juggernaut.",
+		});
+	},
+};

--- a/commands/EDR.js
+++ b/commands/EDR.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('sarcastic EDR response'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'30 Clicks over a 10 hour period to get half a boss worth dps?\nSounds like a good use of my time.',

--- a/commands/EDR.js
+++ b/commands/EDR.js
@@ -1,14 +1,17 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("edr")
-        .setDescription("sarcastic EDR response"),
+	data: new SlashCommandBuilder()
+		.setName('edr')
+		.setDescription('sarcastic EDR response'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "30 Clicks over a 10 hour period to get half a boss worth dps?\nSounds like a good use of my time.", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content:
+				'30 Clicks over a 10 hour period to get half a boss worth dps?\nSounds like a good use of my time.',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/FAQ.js
+++ b/commands/FAQ.js
@@ -1,13 +1,13 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("faq")
-        .setDescription("link to FAQ"),
+	data: new SlashCommandBuilder().setName('faq').setDescription('link to FAQ'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "<https://www.reddit.com/r/ClickerHeroes/wiki/index>", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: '<https://www.reddit.com/r/ClickerHeroes/wiki/index>',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/FAQ.js
+++ b/commands/FAQ.js
@@ -1,10 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('faq').setDescription('link to FAQ'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: '<https://www.reddit.com/r/ClickerHeroes/wiki/index>',
 			ephemeral: false,

--- a/commands/Google.js
+++ b/commands/Google.js
@@ -1,13 +1,15 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("google")
-        .setDescription("link to google"),
+	data: new SlashCommandBuilder()
+		.setName('google')
+		.setDescription('link to google'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "https://www.google.com/", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'https://www.google.com/',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/Google.js
+++ b/commands/Google.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('link to google'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'https://www.google.com/',
 			ephemeral: false,

--- a/commands/OOM.js
+++ b/commands/OOM.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('order(s) of magnitude'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'Order(s) of Magnitude',
 			ephemeral: false,

--- a/commands/OOM.js
+++ b/commands/OOM.js
@@ -1,13 +1,15 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("oom")
-        .setDescription("order(s) of magnitude"),
+	data: new SlashCommandBuilder()
+		.setName('oom')
+		.setDescription('order(s) of magnitude'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "Order(s) of Magnitude", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'Order(s) of Magnitude',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/active.js
+++ b/commands/active.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("active")
-        .setDescription("Basic active guide"),
+	data: new SlashCommandBuilder()
+		.setName('active')
+		.setDescription('Basic active guide'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "How to play active:\n1. Buy at least 2 autoclickers, placing one on your hero and rest on the monster\n2. Buy all ancients, and select active in your calculator of choice; level accordingly\n3. Use skills after losing instakill (if not infinite yet use LS+GC, then energize reload, then repeat)" })
-    }
+		await interaction.reply({
+			content:
+				'How to play active:\n1. Buy at least 2 autoclickers, placing one on your hero and rest on the monster\n2. Buy all ancients, and select active in your calculator of choice; level accordingly\n3. Use skills after losing instakill (if not infinite yet use LS+GC, then energize reload, then repeat)',
+		});
+	},
 };

--- a/commands/active.js
+++ b/commands/active.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Basic active guide'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'How to play active:\n1. Buy at least 2 autoclickers, placing one on your hero and rest on the monster\n2. Buy all ancients, and select active in your calculator of choice; level accordingly\n3. Use skills after losing instakill (if not infinite yet use LS+GC, then energize reload, then repeat)',

--- a/commands/ancients.js
+++ b/commands/ancients.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("ancients")
-        .setDescription("What are ancients?"),
+	data: new SlashCommandBuilder()
+		.setName('ancients')
+		.setDescription('What are ancients?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Your ancients are a branch of new 'hero' type deities that can be leveled and bought with Hero Souls. Each one does a different function and overall they can affect your ascensions very much. Some Ancients are affected by Outsiders(eg. Atman) and others add direct damage etc." })
-    }
+		await interaction.reply({
+			content:
+				"Your ancients are a branch of new 'hero' type deities that can be leveled and bought with Hero Souls. Each one does a different function and overall they can affect your ascensions very much. Some Ancients are affected by Outsiders(eg. Atman) and others add direct damage etc.",
+		});
+	},
 };

--- a/commands/ancients.js
+++ b/commands/ancients.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('What are ancients?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Your ancients are a branch of new 'hero' type deities that can be leveled and bought with Hero Souls. Each one does a different function and overall they can affect your ascensions very much. Some Ancients are affected by Outsiders(eg. Atman) and others add direct damage etc.",

--- a/commands/areyouhappy.js
+++ b/commands/areyouhappy.js
@@ -1,27 +1,39 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("areyouhappy")
-        .setDescription("annoying pings the users asking if they're happy")
-        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
-        .addUserOption(option =>
-            option.setName('user')
-                .setDescription('the user to ping')
-                .setRequired(true)
-        ),
+	data: new SlashCommandBuilder()
+		.setName('areyouhappy')
+		.setDescription("annoying pings the users asking if they're happy")
+		.setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+		.addUserOption((option) =>
+			option
+				.setName('user')
+				.setDescription('the user to ping')
+				.setRequired(true),
+		),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        const user = options.getUser("user");
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		const user = options.getUser('user');
 
-        await interaction.reply({ content: "sending pings", ephemeral: true }).then(() => {
-
-            setTimeout(() => { channel.send(`${user} are`); }, 1000);
-            setTimeout(() => { channel.send(`${user} you`); }, 2000);
-            setTimeout(() => { channel.send(`${user} happy`); }, 3000);
-            setTimeout(() => { channel.send(`${user} now`); }, 4000);
-            setTimeout(() => { channel.send(`${user} ?`); }, 5000);
-        })
-    }
-}
+		await interaction
+			.reply({ content: 'sending pings', ephemeral: true })
+			.then(() => {
+				setTimeout(() => {
+					channel.send(`${user} are`);
+				}, 1000);
+				setTimeout(() => {
+					channel.send(`${user} you`);
+				}, 2000);
+				setTimeout(() => {
+					channel.send(`${user} happy`);
+				}, 3000);
+				setTimeout(() => {
+					channel.send(`${user} now`);
+				}, 4000);
+				setTimeout(() => {
+					channel.send(`${user} ?`);
+				}, 5000);
+			});
+	},
+};

--- a/commands/as.js
+++ b/commands/as.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("as")
-        .setDescription("Outsider calc link"),
+	data: new SlashCommandBuilder()
+		.setName('as')
+		.setDescription('Outsider calc link'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Ancient Souls or AS should be spent according to <https://driej.github.io/Clicker-Heroes-Outsiders/>, also found in <#207675653091229697>" })
-    }
+		await interaction.reply({
+			content:
+				'Ancient Souls or AS should be spent according to <https://driej.github.io/Clicker-Heroes-Outsiders/>, also found in <#207675653091229697>',
+		});
+	},
 };

--- a/commands/as.js
+++ b/commands/as.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Outsider calc link'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Ancient Souls or AS should be spent according to <https://driej.github.io/Clicker-Heroes-Outsiders/>, also found in <#207675653091229697>',

--- a/commands/ascend.js
+++ b/commands/ascend.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('When to ascend?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Ascend whenever you reach zone 130 or fail a boss, whichever happens later',

--- a/commands/ascend.js
+++ b/commands/ascend.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("ascend")
-        .setDescription("When to ascend?"),
+	data: new SlashCommandBuilder()
+		.setName('ascend')
+		.setDescription('When to ascend?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Ascend whenever you reach zone 130 or fail a boss, whichever happens later" })
-    }
+		await interaction.reply({
+			content:
+				'Ascend whenever you reach zone 130 or fail a boss, whichever happens later',
+		});
+	},
 };

--- a/commands/autoclicker.js
+++ b/commands/autoclicker.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on ACs'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Auto Clickers (ACs) are a mechanic you buy in the ruby shop that cost 1000 + 500n rubies each where n is the number of ACs you currently have.\nAutoclickers can be placed on the monster, hero levelup button, "buy all upgrades", and skills. Usually it\'s recommended to place one AC on your main, gilded hero, and all others on the monster.\nEach AC deals 10 clicks per second, until 5 ACs are placed on the monster, then cps grows according to the formula 10×1.5^(n-1) where n is the number of active ACs on the monsters.\nThe total cost to buy autoclickers 1 to n equals 250n(n+3).',

--- a/commands/autoclicker.js
+++ b/commands/autoclicker.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("autoclicker")
-        .setDescription("Info on ACs"),
+	data: new SlashCommandBuilder()
+		.setName('autoclicker')
+		.setDescription('Info on ACs'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Auto Clickers (ACs) are a mechanic you buy in the ruby shop that cost 1000 + 500n rubies each where n is the number of ACs you currently have.\nAutoclickers can be placed on the monster, hero levelup button, \"buy all upgrades\", and skills. Usually it's recommended to place one AC on your main, gilded hero, and all others on the monster.\nEach AC deals 10 clicks per second, until 5 ACs are placed on the monster, then cps grows according to the formula 10×1.5^(n-1) where n is the number of active ACs on the monsters.\nThe total cost to buy autoclickers 1 to n equals 250n(n+3)." })
-    }
+		await interaction.reply({
+			content:
+				'Auto Clickers (ACs) are a mechanic you buy in the ruby shop that cost 1000 + 500n rubies each where n is the number of ACs you currently have.\nAutoclickers can be placed on the monster, hero levelup button, "buy all upgrades", and skills. Usually it\'s recommended to place one AC on your main, gilded hero, and all others on the monster.\nEach AC deals 10 clicks per second, until 5 ACs are placed on the monster, then cps grows according to the formula 10×1.5^(n-1) where n is the number of active ACs on the monsters.\nThe total cost to buy autoclickers 1 to n equals 250n(n+3).',
+		});
+	},
 };

--- a/commands/bp.js
+++ b/commands/bp.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("bp")
-        .setDescription("List of root2 TP breakpoints"),
+	data: new SlashCommandBuilder()
+		.setName('bp')
+		.setDescription('List of root2 TP breakpoints'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "```AS Needed | TP   | HP scale | HP Scale Starts At\n0         | 2%   | 1.145    | 0\n70        | 3%   | 1.16     | 5000\n300       | 4%   | 1.175    | 20000\n1250      | 6%   | 1.3      | 65000\n2550      | 7%   | n/a      | n/a\n4000      | 8%   | n/a      | n/a\n6400      | 10%  | 1.354    | 150000\n18000     | 15%  | 1.45     | 250000\n40000     | 20%  | 1.55     | 360000\n65000     | 25%  | 1.65     | 370000\n102000    | 30%  | 1.75     | 380000\n145000    | 35%  | 1.85     | 480000\n190000    | 40%  | 1.95     | 500000\n240000    | 45%  | 2.1      | 1000000\n350000    | 50%  | 2.3      | 1200000\n485000    | 55%  | 2.45     | 1400000\n666000    | 60%  | 2.65     | 1500000\n840000    | 70%  | 3        | 2000000\n1200000   | 80%  | 3.3      | 2500000\n1950000   | 90%  | 3.6      | 3000000\n2850000   | 100% | 4        | 3500000 (Final BP)```" })
-    }
+		await interaction.reply({
+			content:
+				'```AS Needed | TP   | HP scale | HP Scale Starts At\n0         | 2%   | 1.145    | 0\n70        | 3%   | 1.16     | 5000\n300       | 4%   | 1.175    | 20000\n1250      | 6%   | 1.3      | 65000\n2550      | 7%   | n/a      | n/a\n4000      | 8%   | n/a      | n/a\n6400      | 10%  | 1.354    | 150000\n18000     | 15%  | 1.45     | 250000\n40000     | 20%  | 1.55     | 360000\n65000     | 25%  | 1.65     | 370000\n102000    | 30%  | 1.75     | 380000\n145000    | 35%  | 1.85     | 480000\n190000    | 40%  | 1.95     | 500000\n240000    | 45%  | 2.1      | 1000000\n350000    | 50%  | 2.3      | 1200000\n485000    | 55%  | 2.45     | 1400000\n666000    | 60%  | 2.65     | 1500000\n840000    | 70%  | 3        | 2000000\n1200000   | 80%  | 3.3      | 2500000\n1950000   | 90%  | 3.6      | 3000000\n2850000   | 100% | 4        | 3500000 (Final BP)```',
+		});
+	},
 };

--- a/commands/bp.js
+++ b/commands/bp.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('List of root2 TP breakpoints'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'```AS Needed | TP   | HP scale | HP Scale Starts At\n0         | 2%   | 1.145    | 0\n70        | 3%   | 1.16     | 5000\n300       | 4%   | 1.175    | 20000\n1250      | 6%   | 1.3      | 65000\n2550      | 7%   | n/a      | n/a\n4000      | 8%   | n/a      | n/a\n6400      | 10%  | 1.354    | 150000\n18000     | 15%  | 1.45     | 250000\n40000     | 20%  | 1.55     | 360000\n65000     | 25%  | 1.65     | 370000\n102000    | 30%  | 1.75     | 380000\n145000    | 35%  | 1.85     | 480000\n190000    | 40%  | 1.95     | 500000\n240000    | 45%  | 2.1      | 1000000\n350000    | 50%  | 2.3      | 1200000\n485000    | 55%  | 2.45     | 1400000\n666000    | 60%  | 2.65     | 1500000\n840000    | 70%  | 3        | 2000000\n1200000   | 80%  | 3.3      | 2500000\n1950000   | 90%  | 3.6      | 3000000\n2850000   | 100% | 4        | 3500000 (Final BP)```',

--- a/commands/calclist.js
+++ b/commands/calclist.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('List of common calculators'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'[Ancients, after ascending](<https://zuils.github.io/ClickerHeroesCalculator/>)\n[Outsiders, after transcending](<https://driej.github.io/Clicker-Heroes-Outsiders/>)\n[Future progression (after 1e21 HS)](<https://driej.github.io/clickerheroes-endgame/>)\n[Timelapses for beyond Z50K](<https://driej.github.io/Clicker-Heroes-Timelapses/>)\n[Video guide for the calcs](<https://youtu.be/dQw4w9WgXcQ>)',

--- a/commands/calclist.js
+++ b/commands/calclist.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("calclist")
-        .setDescription("List of common calculators"),
+	data: new SlashCommandBuilder()
+		.setName('calclist')
+		.setDescription('List of common calculators'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "[Ancients, after ascending](<https://zuils.github.io/ClickerHeroesCalculator/>)\n[Outsiders, after transcending](<https://driej.github.io/Clicker-Heroes-Outsiders/>)\n[Future progression (after 1e21 HS)](<https://driej.github.io/clickerheroes-endgame/>)\n[Timelapses for beyond Z50K](<https://driej.github.io/Clicker-Heroes-Timelapses/>)\n[Video guide for the calcs](<https://youtu.be/dQw4w9WgXcQ>)" })
-    }
+		await interaction.reply({
+			content:
+				'[Ancients, after ascending](<https://zuils.github.io/ClickerHeroesCalculator/>)\n[Outsiders, after transcending](<https://driej.github.io/Clicker-Heroes-Outsiders/>)\n[Future progression (after 1e21 HS)](<https://driej.github.io/clickerheroes-endgame/>)\n[Timelapses for beyond Z50K](<https://driej.github.io/Clicker-Heroes-Timelapses/>)\n[Video guide for the calcs](<https://youtu.be/dQw4w9WgXcQ>)',
+		});
+	},
 };

--- a/commands/clans.js
+++ b/commands/clans.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Where to find active clans?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Search posts in these places for leaders recruiting new members. If you are looking for clans, please don't make your own posts here.\n<#104740000591024128>\n<https://discord.gg/8nCRdYM>\n<https://www.reddit.com/r/ClickerHeroesRecruit>",

--- a/commands/clans.js
+++ b/commands/clans.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("clans")
-        .setDescription("Where to find active clans?"),
+	data: new SlashCommandBuilder()
+		.setName('clans')
+		.setDescription('Where to find active clans?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Search posts in these places for leaders recruiting new members. If you are looking for clans, please don't make your own posts here.\n<#104740000591024128>\n<https://discord.gg/8nCRdYM>\n<https://www.reddit.com/r/ClickerHeroesRecruit>" })
-    }
+		await interaction.reply({
+			content:
+				"Search posts in these places for leaders recruiting new members. If you are looking for clans, please don't make your own posts here.\n<#104740000591024128>\n<https://discord.gg/8nCRdYM>\n<https://www.reddit.com/r/ClickerHeroesRecruit>",
+		});
+	},
 };

--- a/commands/clickmas.js
+++ b/commands/clickmas.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on presents, gained from clickmas event'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'**Presents** can be gained from clicking the bauble and mercenary quests. They give:\n-**Coals, Relics** (coals are useless, relics usually too)\n-**Label makers** (random new name for mercenary, nice for the Leeroy Jenkins achievement)\n-**Rubies** (gaining rubies from presents decreases the chance of getting another ruby. So farming presents for rubies is not effective long-term)\n-**Autoclicker skins** (1/1k chance for the Snowman, 1/100k chance for the Turkey and the Zombie)\n-**Spiked nog** Nogs give +1 cps for +1 hour, both of which stack. So 10 nogs give +10 cps during 10 hours, and 72 nogs give +72 cps for 3 days.\n**If you care about CPS, save Nogs up and use them all at once** for maximal gained clicks.\nAdditionally for clans: The CPS from Spiked Nogs also affect the immortal raids. In some cases this might help for earlier immortal levelups or beating the immortal without help.\n\nFarming presents can be considered if you want the Autoclicker skins or Label makers for Leeroy.\n\n:gift: :christmas_tree::star2: **Happy Clickmas!** :star2: :christmas_tree: :gift:',

--- a/commands/clickmas.js
+++ b/commands/clickmas.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("clickmas")
-        .setDescription("Info on presents, gained from clickmas event"),
+	data: new SlashCommandBuilder()
+		.setName('clickmas')
+		.setDescription('Info on presents, gained from clickmas event'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "**Presents** can be gained from clicking the bauble and mercenary quests. They give:\n-**Coals, Relics** (coals are useless, relics usually too)\n-**Label makers** (random new name for mercenary, nice for the Leeroy Jenkins achievement)\n-**Rubies** (gaining rubies from presents decreases the chance of getting another ruby. So farming presents for rubies is not effective long-term)\n-**Autoclicker skins** (1/1k chance for the Snowman, 1/100k chance for the Turkey and the Zombie)\n-**Spiked nog** Nogs give +1 cps for +1 hour, both of which stack. So 10 nogs give +10 cps during 10 hours, and 72 nogs give +72 cps for 3 days.\n**If you care about CPS, save Nogs up and use them all at once** for maximal gained clicks.\nAdditionally for clans: The CPS from Spiked Nogs also affect the immortal raids. In some cases this might help for earlier immortal levelups or beating the immortal without help.\n\nFarming presents can be considered if you want the Autoclicker skins or Label makers for Leeroy.\n\n:gift: :christmas_tree::star2: **Happy Clickmas!** :star2: :christmas_tree: :gift:" })
-    }
+		await interaction.reply({
+			content:
+				'**Presents** can be gained from clicking the bauble and mercenary quests. They give:\n-**Coals, Relics** (coals are useless, relics usually too)\n-**Label makers** (random new name for mercenary, nice for the Leeroy Jenkins achievement)\n-**Rubies** (gaining rubies from presents decreases the chance of getting another ruby. So farming presents for rubies is not effective long-term)\n-**Autoclicker skins** (1/1k chance for the Snowman, 1/100k chance for the Turkey and the Zombie)\n-**Spiked nog** Nogs give +1 cps for +1 hour, both of which stack. So 10 nogs give +10 cps during 10 hours, and 72 nogs give +72 cps for 3 days.\n**If you care about CPS, save Nogs up and use them all at once** for maximal gained clicks.\nAdditionally for clans: The CPS from Spiked Nogs also affect the immortal raids. In some cases this might help for earlier immortal levelups or beating the immortal without help.\n\nFarming presents can be considered if you want the Autoclicker skins or Label makers for Leeroy.\n\n:gift: :christmas_tree::star2: **Happy Clickmas!** :star2: :christmas_tree: :gift:',
+		});
+	},
 };

--- a/commands/combo.js
+++ b/commands/combo.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("combo")
-        .setDescription("Info on Juggernaut's combo"),
+	data: new SlashCommandBuilder()
+		.setName('combo')
+		.setDescription("Info on Juggernaut's combo"),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Juggernaut's combo lasts 5 minutes after last time you or your autoclicker have clicked monsters. Combo damage does not apply when idle." })
-    }
-}
+		await interaction.reply({
+			content:
+				"Juggernaut's combo lasts 5 minutes after last time you or your autoclicker have clicked monsters. Combo damage does not apply when idle.",
+		});
+	},
+};

--- a/commands/combo.js
+++ b/commands/combo.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription("Info on Juggernaut's combo"),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Juggernaut's combo lasts 5 minutes after last time you or your autoclicker have clicked monsters. Combo damage does not apply when idle.",

--- a/commands/desc.js
+++ b/commands/desc.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('Read the channel description!'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'Read the channel description!',
 			ephemeral: false,

--- a/commands/desc.js
+++ b/commands/desc.js
@@ -1,13 +1,15 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("desc")
-        .setDescription("Read the channel description!"),
+	data: new SlashCommandBuilder()
+		.setName('desc')
+		.setDescription('Read the channel description!'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "Read the channel description!", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'Read the channel description!',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/earlyheroes.js
+++ b/commands/earlyheroes.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("earlyheroes")
-        .setDescription("How to level heroes earlygame?"),
+	data: new SlashCommandBuilder()
+		.setName('earlyheroes')
+		.setDescription('How to level heroes earlygame?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Level the highest hero to 10 and buy the upgrade, then get the previous one to 25 for the next upgrade, then the one before to 50 and so on, till they run out of upgrades (no need to level them any further, for now). Then move to the next hero. Around Beastlord, you can start to get the best hero to 25 before moving to the next and you can get Grant to 50 before you save up for Frostleaf.\nOnce at Frostleaf, continue with /power5." })
-    }
+		await interaction.reply({
+			content:
+				'Level the highest hero to 10 and buy the upgrade, then get the previous one to 25 for the next upgrade, then the one before to 50 and so on, till they run out of upgrades (no need to level them any further, for now). Then move to the next hero. Around Beastlord, you can start to get the best hero to 25 before moving to the next and you can get Grant to 50 before you save up for Frostleaf.\nOnce at Frostleaf, continue with /power5.',
+		});
+	},
 };

--- a/commands/earlyheroes.js
+++ b/commands/earlyheroes.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How to level heroes earlygame?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Level the highest hero to 10 and buy the upgrade, then get the previous one to 25 for the next upgrade, then the one before to 50 and so on, till they run out of upgrades (no need to level them any further, for now). Then move to the next hero. Around Beastlord, you can start to get the best hero to 25 before moving to the next and you can get Grant to 50 before you save up for Frostleaf.\nOnce at Frostleaf, continue with /power5.',

--- a/commands/external.js
+++ b/commands/external.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('External auto clickers, macros, scripts'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Macros, scripts, or external auto clickers are considered cheating in the same sense as it is in any other game, but nothing is in place to stop it. We don't invalidate your experience for it, though, as long as you `experience` the game.\nWe frown upon editing progress. Please don't discuss any form of editing progress. Thank you.",

--- a/commands/external.js
+++ b/commands/external.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("external")
-        .setDescription("External auto clickers, macros, scripts"),
+	data: new SlashCommandBuilder()
+		.setName('external')
+		.setDescription('External auto clickers, macros, scripts'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Macros, scripts, or external auto clickers are considered cheating in the same sense as it is in any other game, but nothing is in place to stop it. We don't invalidate your experience for it, though, as long as you `experience` the game.\nWe frown upon editing progress. Please don't discuss any form of editing progress. Thank you." })
-    }
+		await interaction.reply({
+			content:
+				"Macros, scripts, or external auto clickers are considered cheating in the same sense as it is in any other game, but nothing is in place to stop it. We don't invalidate your experience for it, though, as long as you `experience` the game.\nWe frown upon editing progress. Please don't discuss any form of editing progress. Thank you.",
+		});
+	},
 };

--- a/commands/fant.js
+++ b/commands/fant.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("fant")
-        .setDescription("First Ascension New Transcension"),
+	data: new SlashCommandBuilder()
+		.setName('fant')
+		.setDescription('First Ascension New Transcension'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "First Ascension New Transcension", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content: 'First Ascension New Transcension',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/fant.js
+++ b/commands/fant.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('First Ascension New Transcension'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: 'First Ascension New Transcension',
 			ephemeral: false,

--- a/commands/fatgas.js
+++ b/commands/fatgas.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('First Ascensions That Gain Ancient Souls'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'First Ascensions That Gain Ancient Souls',
 			ephemeral: false,

--- a/commands/fatgas.js
+++ b/commands/fatgas.js
@@ -1,13 +1,15 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("fatgas")
-        .setDescription("First Ascensions That Gain Ancient Souls"),
+	data: new SlashCommandBuilder()
+		.setName('fatgas')
+		.setDescription('First Ascensions That Gain Ancient Souls'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "First Ascensions That Gain Ancient Souls", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'First Ascensions That Gain Ancient Souls',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/firstascension.js
+++ b/commands/firstascension.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('When to do your first ascension'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Your first ascension should be at zone 130 unless your progress hasn’t slowed down. Make sure you have leveled all previous heroes as high as possible, as every 2000 hero levels grants 1 Hero Soul. Following this, ascend whenever you fail bosses after zone 130, until you get to zone 300 and transcend.',

--- a/commands/firstascension.js
+++ b/commands/firstascension.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("firstascension")
-        .setDescription("When to do your first ascension"),
+	data: new SlashCommandBuilder()
+		.setName('firstascension')
+		.setDescription('When to do your first ascension'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Your first ascension should be at zone 130 unless your progress hasn’t slowed down. Make sure you have leveled all previous heroes as high as possible, as every 2000 hero levels grants 1 Hero Soul. Following this, ascend whenever you fail bosses after zone 130, until you get to zone 300 and transcend." })
-    }
+		await interaction.reply({
+			content:
+				'Your first ascension should be at zone 130 unless your progress hasn’t slowed down. Make sure you have leveled all previous heroes as high as possible, as every 2000 hero levels grants 1 Hero Soul. Following this, ascend whenever you fail bosses after zone 130, until you get to zone 300 and transcend.',
+		});
+	},
 };

--- a/commands/firsttrans.js
+++ b/commands/firsttrans.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("firsttrans")
-        .setDescription("Info for at first transcension"),
+	data: new SlashCommandBuilder()
+		.setName('firsttrans')
+		.setDescription('Info for at first transcension'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "After having reached zone 300 for the first time, transcend, and use https://driej.github.io/Clicker-Heroes-Outsiders/ in order to allocate your gained Ancient Souls.\nAscend at zone 130 for FANT(First Ascension New Transcendence). Priority ancients are Siya/Lib/Nog if idle, Frags/Jugg/Bhaal/Pluto if active or hybrid, and Kuma/Atman regardless of build. Use one of the ancient calculators in <#207675653091229697> to level them. Ascend when you fail bosses past zone 130, and  make sure to have bought all ancients by around 1M HS. Driej's outsider calculator also provides a rough estimate to when to transcend in the yellow box, assuming an active/hybrid build. Transcend every 3-4 ascensions that **gain Ancient Souls** following this." })
-    }
+		await interaction.reply({
+			content:
+				"After having reached zone 300 for the first time, transcend, and use https://driej.github.io/Clicker-Heroes-Outsiders/ in order to allocate your gained Ancient Souls.\nAscend at zone 130 for FANT(First Ascension New Transcendence). Priority ancients are Siya/Lib/Nog if idle, Frags/Jugg/Bhaal/Pluto if active or hybrid, and Kuma/Atman regardless of build. Use one of the ancient calculators in <#207675653091229697> to level them. Ascend when you fail bosses past zone 130, and  make sure to have bought all ancients by around 1M HS. Driej's outsider calculator also provides a rough estimate to when to transcend in the yellow box, assuming an active/hybrid build. Transcend every 3-4 ascensions that **gain Ancient Souls** following this.",
+		});
+	},
 };

--- a/commands/firsttrans.js
+++ b/commands/firsttrans.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info for at first transcension'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"After having reached zone 300 for the first time, transcend, and use https://driej.github.io/Clicker-Heroes-Outsiders/ in order to allocate your gained Ancient Souls.\nAscend at zone 130 for FANT(First Ascension New Transcendence). Priority ancients are Siya/Lib/Nog if idle, Frags/Jugg/Bhaal/Pluto if active or hybrid, and Kuma/Atman regardless of build. Use one of the ancient calculators in <#207675653091229697> to level them. Ascend when you fail bosses past zone 130, and  make sure to have bought all ancients by around 1M HS. Driej's outsider calculator also provides a rough estimate to when to transcend in the yellow box, assuming an active/hybrid build. Transcend every 3-4 ascensions that **gain Ancient Souls** following this.",

--- a/commands/getarole.js
+++ b/commands/getarole.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How to get a role for image perms'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"This server requires people to DM <@260615392685326336> in order to get roles and image permissions to regulate spam bots.\n<#954519741018554478> explains the process. Remember that roles aren't always given out instantly by the bot.",

--- a/commands/getarole.js
+++ b/commands/getarole.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("getarole")
-        .setDescription("How to get a role for image perms"),
+	data: new SlashCommandBuilder()
+		.setName('getarole')
+		.setDescription('How to get a role for image perms'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "This server requires people to DM <@260615392685326336> in order to get roles and image permissions to regulate spam bots.\n<#954519741018554478> explains the process. Remember that roles aren't always given out instantly by the bot." })
-    }
+		await interaction.reply({
+			content:
+				"This server requires people to DM <@260615392685326336> in order to get roles and image permissions to regulate spam bots.\n<#954519741018554478> explains the process. Remember that roles aren't always given out instantly by the bot.",
+		});
+	},
 };

--- a/commands/gilds.js
+++ b/commands/gilds.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on early gilding, and gildchart link'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"- Don't even touch gilds during the first two ascensions.\n- Once you stop instakilling on the second one, open them all at once, at least some will fall on your best hero which is enough to keep going, all without spending HS for regilding.\n- When you can level Atlas to 725, start using the [gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>). Limit to moving only a few gilds at first, move all gilds once easily affordable.",

--- a/commands/gilds.js
+++ b/commands/gilds.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("gilds")
-        .setDescription("Info on early gilding, and gildchart link"),
+	data: new SlashCommandBuilder()
+		.setName('gilds')
+		.setDescription('Info on early gilding, and gildchart link'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "- Don't even touch gilds during the first two ascensions.\n- Once you stop instakilling on the second one, open them all at once, at least some will fall on your best hero which is enough to keep going, all without spending HS for regilding.\n- When you can level Atlas to 725, start using the [gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>). Limit to moving only a few gilds at first, move all gilds once easily affordable." })
-    }
+		await interaction.reply({
+			content:
+				"- Don't even touch gilds during the first two ascensions.\n- Once you stop instakilling on the second one, open them all at once, at least some will fall on your best hero which is enough to keep going, all without spending HS for regilding.\n- When you can level Atlas to 725, start using the [gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>). Limit to moving only a few gilds at first, move all gilds once easily affordable.",
+		});
+	},
 };

--- a/commands/glossary.js
+++ b/commands/glossary.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Reddit glossary link'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: '<https://www.reddit.com/r/ClickerHeroes/wiki/glossary>',
 		});

--- a/commands/glossary.js
+++ b/commands/glossary.js
@@ -1,13 +1,15 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("glossary")
-        .setDescription("Reddit glossary link"),
+	data: new SlashCommandBuilder()
+		.setName('glossary')
+		.setDescription('Reddit glossary link'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "<https://www.reddit.com/r/ClickerHeroes/wiki/glossary>" })
-    }
+		await interaction.reply({
+			content: '<https://www.reddit.com/r/ClickerHeroes/wiki/glossary>',
+		});
+	},
 };

--- a/commands/guide.js
+++ b/commands/guide.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('General guide link'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'General guide: <https://docs.google.com/document/d/e/2PACX-1vSNZfQsM6Tkofdjjz9om2G7YX9gkxavSicxAwlfZz7eBIQ4xrtvRU4x-vkhBeblGQD_-_7rBkq68oyG/pub>',

--- a/commands/guide.js
+++ b/commands/guide.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("guide")
-        .setDescription("General guide link"),
+	data: new SlashCommandBuilder()
+		.setName('guide')
+		.setDescription('General guide link'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "General guide: <https://docs.google.com/document/d/e/2PACX-1vSNZfQsM6Tkofdjjz9om2G7YX9gkxavSicxAwlfZz7eBIQ4xrtvRU4x-vkhBeblGQD_-_7rBkq68oyG/pub>" })
-    }
+		await interaction.reply({
+			content:
+				'General guide: <https://docs.google.com/document/d/e/2PACX-1vSNZfQsM6Tkofdjjz9om2G7YX9gkxavSicxAwlfZz7eBIQ4xrtvRU4x-vkhBeblGQD_-_7rBkq68oyG/pub>',
+		});
+	},
 };

--- a/commands/guido.js
+++ b/commands/guido.js
@@ -1,14 +1,17 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("guido")
-        .setDescription("snarky guide"),
+	data: new SlashCommandBuilder()
+		.setName('guido')
+		.setDescription('snarky guide'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Hey you! Yes, you! Check out this outdated guide! It's super sarcastic but not as dry and dense as other guides we have to offer! Maybe the snarky nature will help you figure out how to play the game a teeny bit better. Enjoy! \n<https://www.reddit.com/r/ClickerHeroes/comments/4poez0/i_just_made_this_because_i_was_bored/>", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content:
+				"Hey you! Yes, you! Check out this outdated guide! It's super sarcastic but not as dry and dense as other guides we have to offer! Maybe the snarky nature will help you figure out how to play the game a teeny bit better. Enjoy! \n<https://www.reddit.com/r/ClickerHeroes/comments/4poez0/i_just_made_this_because_i_was_bored/>",
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/guido.js
+++ b/commands/guido.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('snarky guide'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Hey you! Yes, you! Check out this outdated guide! It's super sarcastic but not as dry and dense as other guides we have to offer! Maybe the snarky nature will help you figure out how to play the game a teeny bit better. Enjoy! \n<https://www.reddit.com/r/ClickerHeroes/comments/4poez0/i_just_made_this_because_i_was_bored/>",

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -1,13 +1,13 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("guild")
-        .setDescription("It's gilds"),
+	data: new SlashCommandBuilder().setName('guild').setDescription("It's gilds"),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "It's gilds <:kappa:707958927253569556>", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: "It's gilds <:kappa:707958927253569556>",
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -1,10 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('guild').setDescription("It's gilds"),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: "It's gilds <:kappa:707958927253569556>",
 			ephemeral: false,

--- a/commands/herosouls.js
+++ b/commands/herosouls.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on HS'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Hero Souls (HS) are a currency gained mainly from Primal Bosses, as well as clans and mercenary quests. Each HS provides a 10% additive dps gain, and can be used to level/purchase ancients. Ancient benefits are multiplicative with added Hero Souls dps.',

--- a/commands/herosouls.js
+++ b/commands/herosouls.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("herosouls")
-        .setDescription("Info on HS"),
+	data: new SlashCommandBuilder()
+		.setName('herosouls')
+		.setDescription('Info on HS'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Hero Souls (HS) are a currency gained mainly from Primal Bosses, as well as clans and mercenary quests. Each HS provides a 10% additive dps gain, and can be used to level/purchase ancients. Ancient benefits are multiplicative with added Hero Souls dps." })
-    }
+		await interaction.reply({
+			content:
+				'Hero Souls (HS) are a currency gained mainly from Primal Bosses, as well as clans and mercenary quests. Each HS provides a 10% additive dps gain, and can be used to level/purchase ancients. Ancient benefits are multiplicative with added Hero Souls dps.',
+		});
+	},
 };

--- a/commands/hybrid.js
+++ b/commands/hybrid.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("hybrid")
-        .setDescription("Info on hybrid"),
+	data: new SlashCommandBuilder()
+		.setName('hybrid')
+		.setDescription('Info on hybrid'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Hybrid is a build that uses elements of Active and Idle. Suggested when you have at least 1 Autoclicker.\n1.) Select Hybrid in your ancient calculator and level ancients accordingly.\n2.) Use idle until it fails to beat bosses, or if you are higher than zone 50K, until timelapses are done.\n3.) Switch to active using your autoclicker(s) until you fail a boss again after having used skills/gilded the right hero etc.\nnote: as long as the game is open there is no reason to stay idle. Active is always stronger, and is usually better for gold with Golden Clicks active." })
-    }
+		await interaction.reply({
+			content:
+				'Hybrid is a build that uses elements of Active and Idle. Suggested when you have at least 1 Autoclicker.\n1.) Select Hybrid in your ancient calculator and level ancients accordingly.\n2.) Use idle until it fails to beat bosses, or if you are higher than zone 50K, until timelapses are done.\n3.) Switch to active using your autoclicker(s) until you fail a boss again after having used skills/gilded the right hero etc.\nnote: as long as the game is open there is no reason to stay idle. Active is always stronger, and is usually better for gold with Golden Clicks active.',
+		});
+	},
 };

--- a/commands/hybrid.js
+++ b/commands/hybrid.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on hybrid'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Hybrid is a build that uses elements of Active and Idle. Suggested when you have at least 1 Autoclicker.\n1.) Select Hybrid in your ancient calculator and level ancients accordingly.\n2.) Use idle until it fails to beat bosses, or if you are higher than zone 50K, until timelapses are done.\n3.) Switch to active using your autoclicker(s) until you fail a boss again after having used skills/gilded the right hero etc.\nnote: as long as the game is open there is no reason to stay idle. Active is always stronger, and is usually better for gold with Golden Clicks active.',

--- a/commands/hybridactive.js
+++ b/commands/hybridactive.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('When to use hybrid versus active?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"**Active** is ideal under 50k zones because you won't be using TLs.\n**Hybrid** is ideal between 50k and 250k zones because you'll be using TLs.\n**Active** is ideal between 250k and 1m zones because you won't be using TLs.  **Hybrid** is ideal after 1m because you'll be using TLs.",

--- a/commands/hybridactive.js
+++ b/commands/hybridactive.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("hybridactive")
-        .setDescription("When to use hybrid versus active?"),
+	data: new SlashCommandBuilder()
+		.setName('hybridactive')
+		.setDescription('When to use hybrid versus active?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "**Active** is ideal under 50k zones because you won't be using TLs.\n**Hybrid** is ideal between 50k and 250k zones because you'll be using TLs.\n**Active** is ideal between 250k and 1m zones because you won't be using TLs.  **Hybrid** is ideal after 1m because you'll be using TLs." })
-    }
+		await interaction.reply({
+			content:
+				"**Active** is ideal under 50k zones because you won't be using TLs.\n**Hybrid** is ideal between 50k and 250k zones because you'll be using TLs.\n**Active** is ideal between 250k and 1m zones because you won't be using TLs.  **Hybrid** is ideal after 1m because you'll be using TLs.",
+		});
+	},
 };

--- a/commands/idle.js
+++ b/commands/idle.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How bad is idle exactly?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Idle builds make use of the idle status, idle ancient benefits, and the Outsider Xyliqil. The Idle Ancients are Siyalatas, Libertas, and Nogardnit. Nogardnit makes use of Auto Clickers, so you need those as well.\nHowever, idle is far worse than active because it lacks one ancient, lacks the same instant kill speed, and lacks the ability to make use of most skills. Xyliqil is not significant in any way, and is the only unique benefit of idle, meaning active simply brings more to the table for damage.',

--- a/commands/idle.js
+++ b/commands/idle.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("idle")
-        .setDescription("How bad is idle exactly?"),
+	data: new SlashCommandBuilder()
+		.setName('idle')
+		.setDescription('How bad is idle exactly?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Idle builds make use of the idle status, idle ancient benefits, and the Outsider Xyliqil. The Idle Ancients are Siyalatas, Libertas, and Nogardnit. Nogardnit makes use of Auto Clickers, so you need those as well.\nHowever, idle is far worse than active because it lacks one ancient, lacks the same instant kill speed, and lacks the ability to make use of most skills. Xyliqil is not significant in any way, and is the only unique benefit of idle, meaning active simply brings more to the table for damage." })
-    }
+		await interaction.reply({
+			content:
+				'Idle builds make use of the idle status, idle ancient benefits, and the Outsider Xyliqil. The Idle Ancients are Siyalatas, Libertas, and Nogardnit. Nogardnit makes use of Auto Clickers, so you need those as well.\nHowever, idle is far worse than active because it lacks one ancient, lacks the same instant kill speed, and lacks the ability to make use of most skills. Xyliqil is not significant in any way, and is the only unique benefit of idle, meaning active simply brings more to the table for damage.',
+		});
+	},
 };

--- a/commands/image.js
+++ b/commands/image.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/image.js
+++ b/commands/image.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const util = require('util');
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/commands/image.js
+++ b/commands/image.js
@@ -1,72 +1,88 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const util = require("util");
+const util = require('util');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("image")
-        .setDescription("select from a catered list of images to post")
-        .addStringOption(option =>
-            option.setName('query')
-                .setDescription('image to search for')
-                .setAutocomplete(true)),
+	data: new SlashCommandBuilder()
+		.setName('image')
+		.setDescription('select from a catered list of images to post')
+		.addStringOption((option) =>
+			option
+				.setName('query')
+				.setDescription('image to search for')
+				.setAutocomplete(true),
+		),
 
-    async autoComplete(interaction) {
-        const focusedValue = interaction.options.getFocused();
-        const choices = {
-            "numberwang": "https://tenor.com/view/numberwang-thatsnumberwang-thatmitchellandwebblook-gif-7985932",
-            "ha": "http://media.tumblr.com/tumblr_lwhcchZYDv1qdetkro1_500.jpg",
-            "haha": "http://pictures.mastermarf.com/blog/2011/110226-laugh.jpg",
-            "fingerguns": "https://i.imgur.com/NLwQBFV.png",
-            "hm": "http://i.imgur.com/1sdt3QE.gifv",
-            "iguess": "https://i.imgur.com/G1F1ECN.png",
-            "fucked": "https://i.ytimg.com/vi/eh0mDYfTCtE/maxresdefault.jpg",
-            "fuck": "https://imgur.com/a/AUYFeun",
-            "fish": "http://i.imgur.com/5iCpnvM.png",
-            "dumstered": "https://media.giphy.com/media/9w4omxSdj5rSo/giphy.gif",
-            "it": "https://www.resolvetech.co.uk/wp-content/uploads/2016/01/Hello-IT-Have.jpg",
-            "abe": "https://media.giphy.com/media/fDO2Nk0ImzvvW/giphy.gif",
-            "angry": "https://cdn.discordapp.com/attachments/104739787872694272/575381295912189960/AngryCidNoises.png",
-            "alot": "http://thewritepractice.com/wp-content/uploads/2012/05/Alot-vs-a-lot1-600x450.png",
-            "ants": "https://imgur.com/MWg8sz0",
-            "bait1": "https://s-media-cache-ak0.pinimg.com/736x/a3/e6/c1/a3e6c10155f5b255a7f1916c0419ee67.jpg",
-            "bait2": "https://i.gyazo.com/63be20c9e37dd6042a87f6fba70dfd16.png",
-            "bait3": "https://media.giphy.com/media/srTYyZ1BjBtGU/giphy.gif",
-            "banne": "https://gfycat.com/BountifulAmpleAffenpinscher",
-            "banned": "https://imgflip.com/i/1bfvul",
-            "bee": "https://imgur.com/cvLayuf",
-            "borsh": "https://cdn.discordapp.com/attachments/204337434563969024/242094180363403264/point75lord.png",
-            "clown": "https://cdn.discordapp.com/attachments/683185506976268290/849306360323768400/unknown.png",
-            "delet": "https://imgur.com/ccma3VM",
-            "fewer": "https://i.imgur.com/Qb0eIjz.gifv",
-            "facepalm": "http://i.imgur.com/68yp673.jpg",
-            "gud": "https://imgur.com/9AKDl3R",
-            "language": "https://i.imgur.com/DAjvol6.jpg",
-            "neat": "http://i0.kym-cdn.com/entries/icons/original/000/015/044/b5f.jpg",
-            "notok": "http://i.imgur.com/Du2IwBF.png",
-            "nerd": "http://giphy.com/gifs/nerd-reaction-the-simpsons-OMK7LRBedcnhm",
-            "magic": "http://i.imgur.com/YsbKHg1.gif",
-            "popcorn": "https://giphy.com/gifs/eating-michael-jackson-thriller-iLgbO6Y4EoRc4",
-            "pst": "https://i.imgur.com/sP1Vj7j.jpg",
-            "reference": "http://i.imgur.com/XS5LK.gif",
-            "rip": "https://cdn.discordapp.com/attachments/260159911822884866/983516353321377792/unknown.png",
-            "salty": "You right now https://upload.wikimedia.org/wikipedia/commons/a/a2/Salt_mine_0096.jpg",
-            "shame": "https://i.imgur.com/9Ox4xBK.gif",
-            "soon": "https://i.imgur.com/klzVsIJ.png",
-            "stop": "https://giphy.com/gifs/BYhoMtJMQsYVy",
-            "sure": "http://www.reactiongifs.com/r/2013/06/I-dont-believe-you.gif",
-            "tldr": "https://cdn.discordapp.com/attachments/259897497554649098/732022539576016896/main-qimg-0995fc35572e8eb49818519996b41357.png",
-            "watman": "https://pygospasprofession.files.wordpress.com/2013/07/watman.jpg",
-            "well": "http://i.imgur.com/U5ISRyL.gifv",
-            "whoosh": "https://i.imgur.com/axJmn.gif",
-            "um": "https://i.imgur.com/YAGpXPd.png"
-        }
+	async autoComplete(interaction) {
+		const focusedValue = interaction.options.getFocused();
+		const choices = {
+			numberwang:
+				'https://tenor.com/view/numberwang-thatsnumberwang-thatmitchellandwebblook-gif-7985932',
+			ha: 'http://media.tumblr.com/tumblr_lwhcchZYDv1qdetkro1_500.jpg',
+			haha: 'http://pictures.mastermarf.com/blog/2011/110226-laugh.jpg',
+			fingerguns: 'https://i.imgur.com/NLwQBFV.png',
+			hm: 'http://i.imgur.com/1sdt3QE.gifv',
+			iguess: 'https://i.imgur.com/G1F1ECN.png',
+			fucked: 'https://i.ytimg.com/vi/eh0mDYfTCtE/maxresdefault.jpg',
+			fuck: 'https://imgur.com/a/AUYFeun',
+			fish: 'http://i.imgur.com/5iCpnvM.png',
+			dumstered: 'https://media.giphy.com/media/9w4omxSdj5rSo/giphy.gif',
+			it: 'https://www.resolvetech.co.uk/wp-content/uploads/2016/01/Hello-IT-Have.jpg',
+			abe: 'https://media.giphy.com/media/fDO2Nk0ImzvvW/giphy.gif',
+			angry:
+				'https://cdn.discordapp.com/attachments/104739787872694272/575381295912189960/AngryCidNoises.png',
+			alot: 'http://thewritepractice.com/wp-content/uploads/2012/05/Alot-vs-a-lot1-600x450.png',
+			ants: 'https://imgur.com/MWg8sz0',
+			bait1:
+				'https://s-media-cache-ak0.pinimg.com/736x/a3/e6/c1/a3e6c10155f5b255a7f1916c0419ee67.jpg',
+			bait2: 'https://i.gyazo.com/63be20c9e37dd6042a87f6fba70dfd16.png',
+			bait3: 'https://media.giphy.com/media/srTYyZ1BjBtGU/giphy.gif',
+			banne: 'https://gfycat.com/BountifulAmpleAffenpinscher',
+			banned: 'https://imgflip.com/i/1bfvul',
+			bee: 'https://imgur.com/cvLayuf',
+			borsh:
+				'https://cdn.discordapp.com/attachments/204337434563969024/242094180363403264/point75lord.png',
+			clown:
+				'https://cdn.discordapp.com/attachments/683185506976268290/849306360323768400/unknown.png',
+			delet: 'https://imgur.com/ccma3VM',
+			fewer: 'https://i.imgur.com/Qb0eIjz.gifv',
+			facepalm: 'http://i.imgur.com/68yp673.jpg',
+			gud: 'https://imgur.com/9AKDl3R',
+			language: 'https://i.imgur.com/DAjvol6.jpg',
+			neat: 'http://i0.kym-cdn.com/entries/icons/original/000/015/044/b5f.jpg',
+			notok: 'http://i.imgur.com/Du2IwBF.png',
+			nerd: 'http://giphy.com/gifs/nerd-reaction-the-simpsons-OMK7LRBedcnhm',
+			magic: 'http://i.imgur.com/YsbKHg1.gif',
+			popcorn:
+				'https://giphy.com/gifs/eating-michael-jackson-thriller-iLgbO6Y4EoRc4',
+			pst: 'https://i.imgur.com/sP1Vj7j.jpg',
+			reference: 'http://i.imgur.com/XS5LK.gif',
+			rip: 'https://cdn.discordapp.com/attachments/260159911822884866/983516353321377792/unknown.png',
+			salty:
+				'You right now https://upload.wikimedia.org/wikipedia/commons/a/a2/Salt_mine_0096.jpg',
+			shame: 'https://i.imgur.com/9Ox4xBK.gif',
+			soon: 'https://i.imgur.com/klzVsIJ.png',
+			stop: 'https://giphy.com/gifs/BYhoMtJMQsYVy',
+			sure: 'http://www.reactiongifs.com/r/2013/06/I-dont-believe-you.gif',
+			tldr: 'https://cdn.discordapp.com/attachments/259897497554649098/732022539576016896/main-qimg-0995fc35572e8eb49818519996b41357.png',
+			watman:
+				'https://pygospasprofession.files.wordpress.com/2013/07/watman.jpg',
+			well: 'http://i.imgur.com/U5ISRyL.gifv',
+			whoosh: 'https://i.imgur.com/axJmn.gif',
+			um: 'https://i.imgur.com/YAGpXPd.png',
+		};
 
-        const filtered = Object.keys(choices).filter(choice => choice.startsWith(focusedValue))
+		const filtered = Object.keys(choices).filter((choice) =>
+			choice.startsWith(focusedValue),
+		);
 
-        await interaction.respond(filtered.map(choice => ({ name: choice, value: choices[choice] })))
-    },
+		await interaction.respond(
+			filtered.map((choice) => ({ name: choice, value: choices[choice] })),
+		);
+	},
 
-    async execute(interaction) {
-        await interaction.reply({ content: interaction.options._hoistedOptions[0].value });
-    }
-}
+	async execute(interaction) {
+		await interaction.reply({
+			content: interaction.options._hoistedOptions[0].value,
+		});
+	},
+};

--- a/commands/inv.js
+++ b/commands/inv.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('the official link to the discord server'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Official invite to this Discord server: \nhttps://discord.gg/playsaurus',

--- a/commands/inv.js
+++ b/commands/inv.js
@@ -1,14 +1,17 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("inv")
-        .setDescription("the official link to the discord server"),
+	data: new SlashCommandBuilder()
+		.setName('inv')
+		.setDescription('the official link to the discord server'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Official invite to this Discord server: \nhttps://discord.gg/playsaurus", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content:
+				'Official invite to this Discord server: \nhttps://discord.gg/playsaurus',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/ios.js
+++ b/commands/ios.js
@@ -1,13 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("ios")
-        .setDescription("why the import button isnt on IOS"),
+	data: new SlashCommandBuilder()
+		.setName('ios')
+		.setDescription('why the import button isnt on IOS'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "Apple guidelines forced Playsaurus to remove the import button on IOS CH.", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content:
+				'Apple guidelines forced Playsaurus to remove the import button on IOS CH.',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/ios.js
+++ b/commands/ios.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('why the import button isnt on IOS'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content:
 				'Apple guidelines forced Playsaurus to remove the import button on IOS CH.',

--- a/commands/irisexp.js
+++ b/commands/irisexp.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("irisexp")
-        .setDescription("The reason why iris was removed"),
+	data: new SlashCommandBuilder()
+		.setName('irisexp')
+		.setDescription('The reason why iris was removed'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Iris was removed in order to compensate for HS rewards growing exponentially. If Iris was to be added back into the game, the HS rewards from every primal would have to be nerfed in the same way they were buffed in the 1.0 patch. So we would be back to shorter runs for less HS. If Iris was to be added with the current rewards, optimal play would be extremely short runs, which would require you to pay 24/7 attention to the game. Kumawakamaru's bonus was long term increased and timelapse progresses through zones in order to increase the progress a bit with the removal of Iris." })
-    }
+		await interaction.reply({
+			content:
+				"Iris was removed in order to compensate for HS rewards growing exponentially. If Iris was to be added back into the game, the HS rewards from every primal would have to be nerfed in the same way they were buffed in the 1.0 patch. So we would be back to shorter runs for less HS. If Iris was to be added with the current rewards, optimal play would be extremely short runs, which would require you to pay 24/7 attention to the game. Kumawakamaru's bonus was long term increased and timelapse progresses through zones in order to increase the progress a bit with the removal of Iris.",
+		});
+	},
 };

--- a/commands/irisexp.js
+++ b/commands/irisexp.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('The reason why iris was removed'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Iris was removed in order to compensate for HS rewards growing exponentially. If Iris was to be added back into the game, the HS rewards from every primal would have to be nerfed in the same way they were buffed in the 1.0 patch. So we would be back to shorter runs for less HS. If Iris was to be added with the current rewards, optimal play would be extremely short runs, which would require you to pay 24/7 attention to the game. Kumawakamaru's bonus was long term increased and timelapse progresses through zones in order to increase the progress a bit with the removal of Iris.",

--- a/commands/lenny1.js
+++ b/commands/lenny1.js
@@ -1,23 +1,27 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("lenny")
-        .setDescription("lenny face")
-        .addStringOption(option =>
-            option.setName('emoji')
-                .setDescription('The lenny face to use')
-                .setRequired(true)
-                .addChoices(
-                    { name: 'normal', value: "( ͡° ͜ʖ ͡°)" },
-                    { name: 'brick', value: "( ͡° ͜ʖ├┬┴┬" },
-                    { name: 'multi', value: "( ͡°( ͡° ͜ʖ( ͡° ͜ʖ ͡°)ʖ ͡°) ͡°)" }
-                )),
+	data: new SlashCommandBuilder()
+		.setName('lenny')
+		.setDescription('lenny face')
+		.addStringOption((option) =>
+			option
+				.setName('emoji')
+				.setDescription('The lenny face to use')
+				.setRequired(true)
+				.addChoices(
+					{ name: 'normal', value: '( ͡° ͜ʖ ͡°)' },
+					{ name: 'brick', value: '( ͡° ͜ʖ├┬┴┬' },
+					{ name: 'multi', value: '( ͡°( ͡° ͜ʖ( ͡° ͜ʖ ͡°)ʖ ͡°) ͡°)' },
+				),
+		),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: options._hoistedOptions[0].value, ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content: options._hoistedOptions[0].value,
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/lenny1.js
+++ b/commands/lenny1.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -17,7 +17,7 @@ module.exports = {
 		),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
+		const { options } = interaction;
 
 		await interaction.reply({
 			content: options._hoistedOptions[0].value,

--- a/commands/lister.js
+++ b/commands/lister.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Clicker lister'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'<https://graceoflives.github.io/clicker-lister/>\nadd 3 backticks before and after the output e.g\n\\`\\`\\`<output>\\`\\`\\`',

--- a/commands/lister.js
+++ b/commands/lister.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("lister")
-        .setDescription("Clicker lister"),
+	data: new SlashCommandBuilder()
+		.setName('lister')
+		.setDescription('Clicker lister'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "<https://graceoflives.github.io/clicker-lister/>\nadd 3 backticks before and after the output e.g\n\\`\\`\\`<output>\\`\\`\\`" })
-    }
+		await interaction.reply({
+			content:
+				'<https://graceoflives.github.io/clicker-lister/>\nadd 3 backticks before and after the output e.g\n\\`\\`\\`<output>\\`\\`\\`',
+		});
+	},
 };

--- a/commands/log.js
+++ b/commands/log.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("log")
-        .setDescription("What is logHS or logGold?"),
+	data: new SlashCommandBuilder()
+		.setName('log')
+		.setDescription('What is logHS or logGold?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "logHS or logGold refers to the number after the e in Scientific Notation. Use Scientific Notation." })
-    }
+		await interaction.reply({
+			content:
+				'logHS or logGold refers to the number after the e in Scientific Notation. Use Scientific Notation.',
+		});
+	},
 };

--- a/commands/log.js
+++ b/commands/log.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('What is logHS or logGold?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'logHS or logGold refers to the number after the e in Scientific Notation. Use Scientific Notation.',

--- a/commands/maxancients.js
+++ b/commands/maxancients.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Ancients with a effect cap'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Ancients reaching their maximum effect at level:\nChronos: 1101\nVaagur: 1440\nKuma: 1498\nAtman: 2880\nDogcog & Revolc: 3743\nFortuna: 14972\nBubos & Dora: 18715',

--- a/commands/maxancients.js
+++ b/commands/maxancients.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("maxancients")
-        .setDescription("Ancients with a effect cap"),
+	data: new SlashCommandBuilder()
+		.setName('maxancients')
+		.setDescription('Ancients with a effect cap'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Ancients reaching their maximum effect at level:\nChronos: 1101\nVaagur: 1440\nKuma: 1498\nAtman: 2880\nDogcog & Revolc: 3743\nFortuna: 14972\nBubos & Dora: 18715" })
-    }
+		await interaction.reply({
+			content:
+				'Ancients reaching their maximum effect at level:\nChronos: 1101\nVaagur: 1440\nKuma: 1498\nAtman: 2880\nDogcog & Revolc: 3743\nFortuna: 14972\nBubos & Dora: 18715',
+		});
+	},
 };

--- a/commands/merc.js
+++ b/commands/merc.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on mercenaries'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Mercenaries are a mechanic unlocked after ascending. They can be sent on quests for rubies, hero souls, relics, skill activations, and recruitment for more (max 5 in total) mercs. Mercs level up once every 24 hours of questing and have a 20% chance to die every 24 hours of questing. They can be revived with rubies or extra lives (if the mercs has them).\nMercs are most useful for gaining rubies, generally ruby quests of about 1 to 8 hours are optimal. More info, including math on what quests are best and when to revive mercs: <https://www.reddit.com/r/ClickerHeroes/comments/ahupf4/ch1_single_mercenary_strategies_for_quests_revive/>',

--- a/commands/merc.js
+++ b/commands/merc.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("merc")
-        .setDescription("Info on mercenaries"),
+	data: new SlashCommandBuilder()
+		.setName('merc')
+		.setDescription('Info on mercenaries'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Mercenaries are a mechanic unlocked after ascending. They can be sent on quests for rubies, hero souls, relics, skill activations, and recruitment for more (max 5 in total) mercs. Mercs level up once every 24 hours of questing and have a 20% chance to die every 24 hours of questing. They can be revived with rubies or extra lives (if the mercs has them).\nMercs are most useful for gaining rubies, generally ruby quests of about 1 to 8 hours are optimal. More info, including math on what quests are best and when to revive mercs: <https://www.reddit.com/r/ClickerHeroes/comments/ahupf4/ch1_single_mercenary_strategies_for_quests_revive/>" })
-    }
+		await interaction.reply({
+			content:
+				'Mercenaries are a mechanic unlocked after ascending. They can be sent on quests for rubies, hero souls, relics, skill activations, and recruitment for more (max 5 in total) mercs. Mercs level up once every 24 hours of questing and have a 20% chance to die every 24 hours of questing. They can be revived with rubies or extra lives (if the mercs has them).\nMercs are most useful for gaining rubies, generally ruby quests of about 1 to 8 hours are optimal. More info, including math on what quests are best and when to revive mercs: <https://www.reddit.com/r/ClickerHeroes/comments/ahupf4/ch1_single_mercenary_strategies_for_quests_revive/>',
+		});
+	},
 };

--- a/commands/morgulis.js
+++ b/commands/morgulis.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("morgulis")
-        .setDescription("What does morgulis do?"),
+	data: new SlashCommandBuilder()
+		.setName('morgulis')
+		.setDescription('What does morgulis do?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Morgulis is an ancient that serves as essentially a bank for your Hero Souls. Whatever you put in has interest applied to it, leading to a 1.1x damage multiplier given enough HS is put in." })
-    }
+		await interaction.reply({
+			content:
+				'Morgulis is an ancient that serves as essentially a bank for your Hero Souls. Whatever you put in has interest applied to it, leading to a 1.1x damage multiplier given enough HS is put in.',
+		});
+	},
 };

--- a/commands/morgulis.js
+++ b/commands/morgulis.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('What does morgulis do?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Morgulis is an ancient that serves as essentially a bank for your Hero Souls. Whatever you put in has interest applied to it, leading to a 1.1x damage multiplier given enough HS is put in.',

--- a/commands/mpz.js
+++ b/commands/mpz.js
@@ -1,13 +1,17 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("mpz")
-        .setDescription("Monsters per zone. The fewer, the faster. We want faster."),
+	data: new SlashCommandBuilder()
+		.setName('mpz')
+		.setDescription(
+			'Monsters per zone. The fewer, the faster. We want faster.',
+		),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "Monsters per zone. The fewer, the faster. We want faster.", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'Monsters per zone. The fewer, the faster. We want faster.',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/mpz.js
+++ b/commands/mpz.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -8,7 +8,6 @@ module.exports = {
 		),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'Monsters per zone. The fewer, the faster. We want faster.',
 			ephemeral: false,

--- a/commands/outsiders.js
+++ b/commands/outsiders.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('What are outsiders?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'The outsiders are essentially super-ancients, which have varied abilities to enhance game play throughout your next transcendence; They are hired and leveled with Ancient Souls.\nOutsider Calculator\nhttps://driej.github.io/Clicker-Heroes-Outsiders/',

--- a/commands/outsiders.js
+++ b/commands/outsiders.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("outsiders")
-        .setDescription("What are outsiders?"),
+	data: new SlashCommandBuilder()
+		.setName('outsiders')
+		.setDescription('What are outsiders?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "The outsiders are essentially super-ancients, which have varied abilities to enhance game play throughout your next transcendence; They are hired and leveled with Ancient Souls.\nOutsider Calculator\nhttps://driej.github.io/Clicker-Heroes-Outsiders/" })
-    }
+		await interaction.reply({
+			content:
+				'The outsiders are essentially super-ancients, which have varied abilities to enhance game play throughout your next transcendence; They are hired and leveled with Ancient Souls.\nOutsider Calculator\nhttps://driej.github.io/Clicker-Heroes-Outsiders/',
+		});
+	},
 };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,11 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('ping').setDescription('Pong!'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({ content: 'Pong!' });
 	},
 };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,13 +1,11 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("ping")
-        .setDescription("Pong!"),
+	data: new SlashCommandBuilder().setName('ping').setDescription('Pong!'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Pong!" })
-    }
+		await interaction.reply({ content: 'Pong!' });
+	},
 };

--- a/commands/pong.js
+++ b/commands/pong.js
@@ -1,13 +1,11 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("pong")
-        .setDescription("Ping!"),
+	data: new SlashCommandBuilder().setName('pong').setDescription('Ping!'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Ping!" })
-    }
+		await interaction.reply({ content: 'Ping!' });
+	},
 };

--- a/commands/pong.js
+++ b/commands/pong.js
@@ -1,11 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('pong').setDescription('Ping!'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({ content: 'Ping!' });
 	},
 };

--- a/commands/power5.js
+++ b/commands/power5.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("power5")
-        .setDescription("Usage of power5 heroes"),
+	data: new SlashCommandBuilder()
+		.setName('power5')
+		.setDescription('Usage of power5 heroes'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Before being able to afford regilding and after getting Frostleaf's final upgrade, you should level **Treebeast, Ivan, Brittany, Samurai, or Seer.**\nThese 5 heroes have the most base/upgrade damage. They need to be level 1000+ for a 10x multiplier.\nPick the one above level 1000 with the most gilds, and in the case of a tie, pick any. If you can afford regilding but haven't reached Atlas's gild point you should regild to Samurai.\nOnce Samurai is level 2425, you can level Atlas to 725 and start using [the gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>)." })
-    }
+		await interaction.reply({
+			content:
+				"Before being able to afford regilding and after getting Frostleaf's final upgrade, you should level **Treebeast, Ivan, Brittany, Samurai, or Seer.**\nThese 5 heroes have the most base/upgrade damage. They need to be level 1000+ for a 10x multiplier.\nPick the one above level 1000 with the most gilds, and in the case of a tie, pick any. If you can afford regilding but haven't reached Atlas's gild point you should regild to Samurai.\nOnce Samurai is level 2425, you can level Atlas to 725 and start using [the gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>).",
+		});
+	},
 };

--- a/commands/power5.js
+++ b/commands/power5.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Usage of power5 heroes'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Before being able to afford regilding and after getting Frostleaf's final upgrade, you should level **Treebeast, Ivan, Brittany, Samurai, or Seer.**\nThese 5 heroes have the most base/upgrade damage. They need to be level 1000+ for a 10x multiplier.\nPick the one above level 1000 with the most gilds, and in the case of a tie, pick any. If you can afford regilding but haven't reached Atlas's gild point you should regild to Samurai.\nOnce Samurai is level 2425, you can level Atlas to 725 and start using [the gild chart](<https://www.reddit.com/r/ClickerHeroes/comments/868uh3/10e11_hero_gilding_chart/>).",

--- a/commands/pretrans.js
+++ b/commands/pretrans.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Ancients before transcending'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Juggernaut is optimal if you have an autoclicker; place it on the monster for combo. Level Jugg when HS is more than his (cost × level).\nOtherwise use idle: get Siyalatas and Libertas, level them equally. Level both up when HS is more than Siya's (cost × level).\nDon't worry about any other ancients until you reach 300 and transcend.",

--- a/commands/pretrans.js
+++ b/commands/pretrans.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("pretrans")
-        .setDescription("Ancients before transcending"),
+	data: new SlashCommandBuilder()
+		.setName('pretrans')
+		.setDescription('Ancients before transcending'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Juggernaut is optimal if you have an autoclicker; place it on the monster for combo. Level Jugg when HS is more than his (cost × level).\nOtherwise use idle: get Siyalatas and Libertas, level them equally. Level both up when HS is more than Siya's (cost × level).\nDon't worry about any other ancients until you reach 300 and transcend." })
-    }
+		await interaction.reply({
+			content:
+				"Juggernaut is optimal if you have an autoclicker; place it on the monster for combo. Level Jugg when HS is more than his (cost × level).\nOtherwise use idle: get Siyalatas and Libertas, level them equally. Level both up when HS is more than Siya's (cost × level).\nDon't worry about any other ancients until you reach 300 and transcend.",
+		});
+	},
 };

--- a/commands/primalbug.js
+++ b/commands/primalbug.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("primalbug")
-        .setDescription("Info on primal bug"),
+	data: new SlashCommandBuilder()
+		.setName('primalbug')
+		.setDescription('Info on primal bug'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "The e12 version of the game has a bug that involves getting 0 Hero Souls from Primal Bosses for the rest of the ascension if you fight a Legacy Immortal Boss. It's recommended to wait until after the ascension is basically over to fight them, and if you end up affected by the bug, ascending is the only option.(Quick Ascensions if above ~250K HZE or merc quests may help)" })
-    }
+		await interaction.reply({
+			content:
+				"The e12 version of the game has a bug that involves getting 0 Hero Souls from Primal Bosses for the rest of the ascension if you fight a Legacy Immortal Boss. It's recommended to wait until after the ascension is basically over to fight them, and if you end up affected by the bug, ascending is the only option.(Quick Ascensions if above ~250K HZE or merc quests may help)",
+		});
+	},
 };

--- a/commands/primalbug.js
+++ b/commands/primalbug.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on primal bug'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"The e12 version of the game has a bug that involves getting 0 Hero Souls from Primal Bosses for the rest of the ascension if you fight a Legacy Immortal Boss. It's recommended to wait until after the ascension is basically over to fight them, and if you end up affected by the bug, ascending is the only option.(Quick Ascensions if above ~250K HZE or merc quests may help)",

--- a/commands/qarush.js
+++ b/commands/qarush.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("qarush")
-        .setDescription("Guide on the QA rush"),
+	data: new SlashCommandBuilder()
+		.setName('qarush')
+		.setDescription('Guide on the QA rush'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "From zone ~250k up to (and including) the first failed boss past 1M, it is better to use Quick Ascensions (QAs), instead of ascending and using TLs to regain most zones.\nIn this 'QA rush' you don't have to ascend at all, but you'll end up using about 66 QAs. This will cost 33k rubies, which you can end up spending in less then a week. So after getting 4 Autoclickers, make sure to save up for this QA rush!\nWhen short on rubies, delay starting with QAs and keep ascending normally, until you have enough rubies for all the remaining QAs.\n\nThe second QA rush comes very quickly after the first one, since the zone 1M transcension doesn't take alot of time to finish. So when you're approaching the first QA rush, consider to save up rubies even after getting 33k." })
-    }
+		await interaction.reply({
+			content:
+				"From zone ~250k up to (and including) the first failed boss past 1M, it is better to use Quick Ascensions (QAs), instead of ascending and using TLs to regain most zones.\nIn this 'QA rush' you don't have to ascend at all, but you'll end up using about 66 QAs. This will cost 33k rubies, which you can end up spending in less then a week. So after getting 4 Autoclickers, make sure to save up for this QA rush!\nWhen short on rubies, delay starting with QAs and keep ascending normally, until you have enough rubies for all the remaining QAs.\n\nThe second QA rush comes very quickly after the first one, since the zone 1M transcension doesn't take alot of time to finish. So when you're approaching the first QA rush, consider to save up rubies even after getting 33k.",
+		});
+	},
 };

--- a/commands/qarush.js
+++ b/commands/qarush.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Guide on the QA rush'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"From zone ~250k up to (and including) the first failed boss past 1M, it is better to use Quick Ascensions (QAs), instead of ascending and using TLs to regain most zones.\nIn this 'QA rush' you don't have to ascend at all, but you'll end up using about 66 QAs. This will cost 33k rubies, which you can end up spending in less then a week. So after getting 4 Autoclickers, make sure to save up for this QA rush!\nWhen short on rubies, delay starting with QAs and keep ascending normally, until you have enough rubies for all the remaining QAs.\n\nThe second QA rush comes very quickly after the first one, since the zone 1M transcension doesn't take alot of time to finish. So when you're approaching the first QA rush, consider to save up rubies even after getting 33k.",

--- a/commands/quickascension.js
+++ b/commands/quickascension.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on QAs'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Quick Ascensions (QAs) can be bought for 500 rubies in the shop. They give the expected average HS you'd gain from ascending at your current zone. This allows you to level ancients and immediately continue from your current zone. They don't give additional HS past zone 1 million, and it's recommended to start using them around zone 250k. (see /qarush)",

--- a/commands/quickascension.js
+++ b/commands/quickascension.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("quickascension")
-        .setDescription("Info on QAs"),
+	data: new SlashCommandBuilder()
+		.setName('quickascension')
+		.setDescription('Info on QAs'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Quick Ascensions (QAs) can be bought for 500 rubies in the shop. They give the expected average HS you'd gain from ascending at your current zone. This allows you to level ancients and immediately continue from your current zone. They don't give additional HS past zone 1 million, and it's recommended to start using them around zone 250k. (see /qarush)" })
-    }
+		await interaction.reply({
+			content:
+				"Quick Ascensions (QAs) can be bought for 500 rubies in the shop. They give the expected average HS you'd gain from ascending at your current zone. This allows you to level ancients and immediately continue from your current zone. They don't give additional HS past zone 1 million, and it's recommended to start using them around zone 250k. (see /qarush)",
+		});
+	},
 };

--- a/commands/raiddamage.js
+++ b/commands/raiddamage.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Damage on legacy immortal'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Legacy raid damage equals the highest amount of HS from primals you earned during a single trans.\nNew raid damage mostly depends on your class level: dmg = 10 * 3^(lvl - 1). There's a 25% bonus if the immortal is weak to your selected class, but this bonus shouldn't matter for long term clans.",

--- a/commands/raiddamage.js
+++ b/commands/raiddamage.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("raiddamage")
-        .setDescription("Damage on legacy immortal"),
+	data: new SlashCommandBuilder()
+		.setName('raiddamage')
+		.setDescription('Damage on legacy immortal'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Legacy raid damage equals the highest amount of HS from primals you earned during a single trans.\nNew raid damage mostly depends on your class level: dmg = 10 * 3^(lvl - 1). There's a 25% bonus if the immortal is weak to your selected class, but this bonus shouldn't matter for long term clans." })
-    }
+		await interaction.reply({
+			content:
+				"Legacy raid damage equals the highest amount of HS from primals you earned during a single trans.\nNew raid damage mostly depends on your class level: dmg = 10 * 3^(lvl - 1). There's a 25% bonus if the immortal is weak to your selected class, but this bonus shouldn't matter for long term clans.",
+		});
+	},
 };

--- a/commands/rarekappa.js
+++ b/commands/rarekappa.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("rarekappa")
-        .setDescription("Chances of the kappa boss"),
+	data: new SlashCommandBuilder()
+		.setName('rarekappa')
+		.setDescription('Chances of the kappa boss'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "0.5% chance on boss zones ending in 0 for zones 30+. Mobile drops that chance to 0.4%. If there's a holiday event that halves the chance to 0.25% and 0.2%. Centurions up to 1000 can't be Kappa. According to u/Xeno234 on <https://www.reddit.com/r/ClickerHeroes/comments/4k0qqz/primal_kappa_percent_chance_got_one_today/>\nSo if you're clearing 8k zones per hour, you'll almost certainly get one, but you won't see it because you'll probably instakill right over it." })
-    }
+		await interaction.reply({
+			content:
+				"0.5% chance on boss zones ending in 0 for zones 30+. Mobile drops that chance to 0.4%. If there's a holiday event that halves the chance to 0.25% and 0.2%. Centurions up to 1000 can't be Kappa. According to u/Xeno234 on <https://www.reddit.com/r/ClickerHeroes/comments/4k0qqz/primal_kappa_percent_chance_got_one_today/>\nSo if you're clearing 8k zones per hour, you'll almost certainly get one, but you won't see it because you'll probably instakill right over it.",
+		});
+	},
 };

--- a/commands/rarekappa.js
+++ b/commands/rarekappa.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Chances of the kappa boss'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"0.5% chance on boss zones ending in 0 for zones 30+. Mobile drops that chance to 0.4%. If there's a holiday event that halves the chance to 0.25% and 0.2%. Centurions up to 1000 can't be Kappa. According to u/Xeno234 on <https://www.reddit.com/r/ClickerHeroes/comments/4k0qqz/primal_kappa_percent_chance_got_one_today/>\nSo if you're clearing 8k zones per hour, you'll almost certainly get one, but you won't see it because you'll probably instakill right over it.",

--- a/commands/rekt.js
+++ b/commands/rekt.js
@@ -1,15 +1,14 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("rekt")
-        .setDescription("rekt list"),
+	data: new SlashCommandBuilder().setName('rekt').setDescription('rekt list'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-
-        await interaction.reply({ content: "☐ Not REKT \n☑️ REKT! \n☑️ PhandoREKT \n☑️ The Great ForREKT Seer \n☑️ AmenhoREKT \n☑️ REKT Knight \n☑️ WepwaREKT \n☑️ Orntchya Gladeye, Didensy REKT \n☑️ Bobby, REKT Hunter \n☑️ Mercedes, Duchess of REKT \n☑️ The Wandering REKTman \n☑️ Cid, the REKTful Adventurer \n☑️ Argaiv, Ancient of REKTment \n☑️ REKTeri jerator, REKT wizard \n☑️ TerREKT \n☑️ REKTvolc, Ancient of Luck \n☑️ Fragsworth, Ancient of REKT \n☑️ REKT'gorloth, the REKTesis cell \n☑️ BerREKTer, Ancient of Rage \n☑️ REKTatoncheir, Ancient of Wallops \n☑️ Athena, Goddess of REKT \n☑️ REKTos, Ancient of Thieves \n☑️ The Dark REKTual \n☑️ REKTload \n☑️ Metal DetREKTor \n☑️ REKTstorm \n☑️ PowerREKT \n☑️ Super REKT \n☑️ Golden REKT \n☑️ REKT Strikes \n☑️ EnerREKT \n☑️ The REKT Samurai \n☑️ Tako REKTurns \n☑️ Woodchip, the REKTent \n☑️ Primal Oversized REKTty \n☑️ REKTy Robot \n☑️ Treasure REKT \n☑️ MushREKT Bloop \n☑️ REKT Scouts" })
-    }
-}
+		await interaction.reply({
+			content:
+				"☐ Not REKT \n☑️ REKT! \n☑️ PhandoREKT \n☑️ The Great ForREKT Seer \n☑️ AmenhoREKT \n☑️ REKT Knight \n☑️ WepwaREKT \n☑️ Orntchya Gladeye, Didensy REKT \n☑️ Bobby, REKT Hunter \n☑️ Mercedes, Duchess of REKT \n☑️ The Wandering REKTman \n☑️ Cid, the REKTful Adventurer \n☑️ Argaiv, Ancient of REKTment \n☑️ REKTeri jerator, REKT wizard \n☑️ TerREKT \n☑️ REKTvolc, Ancient of Luck \n☑️ Fragsworth, Ancient of REKT \n☑️ REKT'gorloth, the REKTesis cell \n☑️ BerREKTer, Ancient of Rage \n☑️ REKTatoncheir, Ancient of Wallops \n☑️ Athena, Goddess of REKT \n☑️ REKTos, Ancient of Thieves \n☑️ The Dark REKTual \n☑️ REKTload \n☑️ Metal DetREKTor \n☑️ REKTstorm \n☑️ PowerREKT \n☑️ Super REKT \n☑️ Golden REKT \n☑️ REKT Strikes \n☑️ EnerREKT \n☑️ The REKT Samurai \n☑️ Tako REKTurns \n☑️ Woodchip, the REKTent \n☑️ Primal Oversized REKTty \n☑️ REKTy Robot \n☑️ Treasure REKT \n☑️ MushREKT Bloop \n☑️ REKT Scouts",
+		});
+	},
+};

--- a/commands/rekt.js
+++ b/commands/rekt.js
@@ -1,11 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('rekt').setDescription('rekt list'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"☐ Not REKT \n☑️ REKT! \n☑️ PhandoREKT \n☑️ The Great ForREKT Seer \n☑️ AmenhoREKT \n☑️ REKT Knight \n☑️ WepwaREKT \n☑️ Orntchya Gladeye, Didensy REKT \n☑️ Bobby, REKT Hunter \n☑️ Mercedes, Duchess of REKT \n☑️ The Wandering REKTman \n☑️ Cid, the REKTful Adventurer \n☑️ Argaiv, Ancient of REKTment \n☑️ REKTeri jerator, REKT wizard \n☑️ TerREKT \n☑️ REKTvolc, Ancient of Luck \n☑️ Fragsworth, Ancient of REKT \n☑️ REKT'gorloth, the REKTesis cell \n☑️ BerREKTer, Ancient of Rage \n☑️ REKTatoncheir, Ancient of Wallops \n☑️ Athena, Goddess of REKT \n☑️ REKTos, Ancient of Thieves \n☑️ The Dark REKTual \n☑️ REKTload \n☑️ Metal DetREKTor \n☑️ REKTstorm \n☑️ PowerREKT \n☑️ Super REKT \n☑️ Golden REKT \n☑️ REKT Strikes \n☑️ EnerREKT \n☑️ The REKT Samurai \n☑️ Tako REKTurns \n☑️ Woodchip, the REKTent \n☑️ Primal Oversized REKTty \n☑️ REKTy Robot \n☑️ Treasure REKT \n☑️ MushREKT Bloop \n☑️ REKT Scouts",

--- a/commands/relics.js
+++ b/commands/relics.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on relics'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Relics are a mechanic in Clicker Heroes that provide levels to the specified ancient. Relic level is based on zone progress, forge cores are based on relic level/rarity. When relics show 0% it is a result of limited precision meaning your actual ancient level is too high to make the relic worthwhile. When this begins to happen relics have become useless as they will be for the majority of the game.',

--- a/commands/relics.js
+++ b/commands/relics.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("relics")
-        .setDescription("Info on relics"),
+	data: new SlashCommandBuilder()
+		.setName('relics')
+		.setDescription('Info on relics'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Relics are a mechanic in Clicker Heroes that provide levels to the specified ancient. Relic level is based on zone progress, forge cores are based on relic level/rarity. When relics show 0% it is a result of limited precision meaning your actual ancient level is too high to make the relic worthwhile. When this begins to happen relics have become useless as they will be for the majority of the game." })
-    }
+		await interaction.reply({
+			content:
+				'Relics are a mechanic in Clicker Heroes that provide levels to the specified ancient. Relic level is based on zone progress, forge cores are based on relic level/rarity. When relics show 0% it is a result of limited precision meaning your actual ancient level is too high to make the relic worthwhile. When this begins to happen relics have become useless as they will be for the majority of the game.',
+		});
+	},
 };

--- a/commands/reset.js
+++ b/commands/reset.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("reset")
-        .setDescription("How to hard reset"),
+	data: new SlashCommandBuilder()
+		.setName('reset')
+		.setDescription('How to hard reset'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "To hard reset on PC, open the ingame settings and select the option to reset. Click yes and yes.\nTo hard reset on mobile, close Clicker Heroes, open app settings, clear app data for Clicker Heroes, disable cloud login, relaunch Clicker Heroes, make sure to export the new save to a file so you can import later when you enable cloud login." })
-    }
+		await interaction.reply({
+			content:
+				'To hard reset on PC, open the ingame settings and select the option to reset. Click yes and yes.\nTo hard reset on mobile, close Clicker Heroes, open app settings, clear app data for Clicker Heroes, disable cloud login, relaunch Clicker Heroes, make sure to export the new save to a file so you can import later when you enable cloud login.',
+		});
+	},
 };

--- a/commands/reset.js
+++ b/commands/reset.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How to hard reset'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'To hard reset on PC, open the ingame settings and select the option to reset. Click yes and yes.\nTo hard reset on mobile, close Clicker Heroes, open app settings, clear app data for Clicker Heroes, disable cloud login, relaunch Clicker Heroes, make sure to export the new save to a file so you can import later when you enable cloud login.',

--- a/commands/root2.js
+++ b/commands/root2.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info and links on root2'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Clicker Heroes Root 2 is a mod of CH made by Nalk and Sioist that reworks heroes, transcendence, and adds a few QOL additions. See https://discord.com/channels/104739787872694272/430434656668614676. A full [list of changes](<https://www.reddit.com/r/ClickerHeroes/comments/8cgnjc/clicker_heroes_root_2_v141421/>) and the [Root2 FAQ](<https://www.reddit.com/r/ClickerHeroes/wiki/faqroot2/>) are on reddit.',

--- a/commands/root2.js
+++ b/commands/root2.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("root2")
-        .setDescription("Info and links on root2"),
+	data: new SlashCommandBuilder()
+		.setName('root2')
+		.setDescription('Info and links on root2'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Clicker Heroes Root 2 is a mod of CH made by Nalk and Sioist that reworks heroes, transcendence, and adds a few QOL additions. See https://discord.com/channels/104739787872694272/430434656668614676. A full [list of changes](<https://www.reddit.com/r/ClickerHeroes/comments/8cgnjc/clicker_heroes_root_2_v141421/>) and the [Root2 FAQ](<https://www.reddit.com/r/ClickerHeroes/wiki/faqroot2/>) are on reddit." })
-    }
+		await interaction.reply({
+			content:
+				'Clicker Heroes Root 2 is a mod of CH made by Nalk and Sioist that reworks heroes, transcendence, and adds a few QOL additions. See https://discord.com/channels/104739787872694272/430434656668614676. A full [list of changes](<https://www.reddit.com/r/ClickerHeroes/comments/8cgnjc/clicker_heroes_root_2_v141421/>) and the [Root2 FAQ](<https://www.reddit.com/r/ClickerHeroes/wiki/faqroot2/>) are on reddit.',
+		});
+	},
 };

--- a/commands/rubies.js
+++ b/commands/rubies.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("rubies")
-        .setDescription("Info on rubies"),
+	data: new SlashCommandBuilder()
+		.setName('rubies')
+		.setDescription('Info on rubies'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Rubies can be collected from Clans, Clickables, as well as Mercs. They are best spent first on 4 Auto Clickers. After this you save up for Timelapses and Quick Ascensions. (TLs are used zone 50K+, QAs used around zone 250K+)\n\nAdditional autoclickers and 2x damage are nice, but no priority. First make sure you have 33k rubies for the QA rush, and enough for TLs.\nNever spend rubies on gilds, relics or instant merc hires." })
-    }
+		await interaction.reply({
+			content:
+				'Rubies can be collected from Clans, Clickables, as well as Mercs. They are best spent first on 4 Auto Clickers. After this you save up for Timelapses and Quick Ascensions. (TLs are used zone 50K+, QAs used around zone 250K+)\n\nAdditional autoclickers and 2x damage are nice, but no priority. First make sure you have 33k rubies for the QA rush, and enough for TLs.\nNever spend rubies on gilds, relics or instant merc hires.',
+		});
+	},
 };

--- a/commands/rubies.js
+++ b/commands/rubies.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on rubies'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Rubies can be collected from Clans, Clickables, as well as Mercs. They are best spent first on 4 Auto Clickers. After this you save up for Timelapses and Quick Ascensions. (TLs are used zone 50K+, QAs used around zone 250K+)\n\nAdditional autoclickers and 2x damage are nice, but no priority. First make sure you have 33k rubies for the QA rush, and enough for TLs.\nNever spend rubies on gilds, relics or instant merc hires.',

--- a/commands/rubys.js
+++ b/commands/rubys.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription("it's rubies"),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: "It's rubies <:kappa:707958927253569556>",
 			ephemeral: false,

--- a/commands/rubys.js
+++ b/commands/rubys.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("rubys")
-        .setDescription("it's rubies"),
+	data: new SlashCommandBuilder()
+		.setName('rubys')
+		.setDescription("it's rubies"),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "It's rubies <:kappa:707958927253569556>", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content: "It's rubies <:kappa:707958927253569556>",
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/rules.js
+++ b/commands/rules.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Mods are the rules.'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: 'Mods **are** the rules.',
 			ephemeral: false,

--- a/commands/rules.js
+++ b/commands/rules.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("rules")
-        .setDescription("Mods are the rules."),
+	data: new SlashCommandBuilder()
+		.setName('rules')
+		.setDescription('Mods are the rules.'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Mods **are** the rules.", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content: 'Mods **are** the rules.',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/sant.js
+++ b/commands/sant.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,7 +6,6 @@ module.exports = {
 		.setDescription('Second Ascension New Transcension'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
 		await interaction.reply({
 			content: 'Second Ascension New Transcension',
 			ephemeral: false,

--- a/commands/sant.js
+++ b/commands/sant.js
@@ -1,13 +1,15 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("sant")
-        .setDescription("Second Ascension New Transcension"),
+	data: new SlashCommandBuilder()
+		.setName('sant')
+		.setDescription('Second Ascension New Transcension'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
-        await interaction.reply({ content: "Second Ascension New Transcension", ephemeral: false })
-    }
-}
+	async execute(interaction) {
+		const { channel, options } = interaction;
+		await interaction.reply({
+			content: 'Second Ascension New Transcension',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/saveconvert.js
+++ b/commands/saveconvert.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("saveconvert")
-        .setDescription("How to convert between mobile and PC"),
+	data: new SlashCommandBuilder()
+		.setName('saveconvert')
+		.setDescription('How to convert between mobile and PC'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Mobile to PC. PC to mobile is same process with swapped devices. **iOS cannot be imported into, see /ios for details**\nSettings --> export --> copy save, open save converter in <#207675653091229697> --> insert save --> get PC save as a result --> take PC save and put it somewhere accessible on the new PC --> take save and import into PC" })
-    }
+		await interaction.reply({
+			content:
+				'Mobile to PC. PC to mobile is same process with swapped devices. **iOS cannot be imported into, see /ios for details**\nSettings --> export --> copy save, open save converter in <#207675653091229697> --> insert save --> get PC save as a result --> take PC save and put it somewhere accessible on the new PC --> take save and import into PC',
+		});
+	},
 };

--- a/commands/saveconvert.js
+++ b/commands/saveconvert.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How to convert between mobile and PC'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Mobile to PC. PC to mobile is same process with swapped devices. **iOS cannot be imported into, see /ios for details**\nSettings --> export --> copy save, open save converter in <#207675653091229697> --> insert save --> get PC save as a result --> take PC save and put it somewhere accessible on the new PC --> take save and import into PC',

--- a/commands/scaling.js
+++ b/commands/scaling.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("scaling")
-        .setDescription("Info on zone scaling"),
+	data: new SlashCommandBuilder()
+		.setName('scaling')
+		.setDescription('Info on zone scaling'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Zone stat changes applied every 500 zones:\n- MPZ: +0.1\n- Boss Timer: -2 seconds\n- TCC: *0.994 (multiplicative, exact value `e^(-0.006)`)\n- Boss Health: +0.4\n- PBC: -2" })
-    }
+		await interaction.reply({
+			content:
+				'Zone stat changes applied every 500 zones:\n- MPZ: +0.1\n- Boss Timer: -2 seconds\n- TCC: *0.994 (multiplicative, exact value `e^(-0.006)`)\n- Boss Health: +0.4\n- PBC: -2',
+		});
+	},
 };

--- a/commands/scaling.js
+++ b/commands/scaling.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on zone scaling'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Zone stat changes applied every 500 zones:\n- MPZ: +0.1\n- Boss Timer: -2 seconds\n- TCC: *0.994 (multiplicative, exact value `e^(-0.006)`)\n- Boss Health: +0.4\n- PBC: -2',

--- a/commands/scinot.js
+++ b/commands/scinot.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('How to read Scientific Notation'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Switch to Scientific Notation (SciNot for short) in the game settings. An example would be the number after e in your gold.\nIn some guides SciNot is known as Log10. SciNot is eventually forced, and agreed by most to be easier to understand than Standard Notation.\nIn this game, Standard is just a hybrid of written form and SciNot. Each subsequent letter correlates to a multiple of e3. It's much simpler to read and understand the context of 1.845e24 than 1.845 septillion.\nHere's a short video on how to read and convert to and from SciNot: <https://youtu.be/bXkewQ7WEdI>",

--- a/commands/scinot.js
+++ b/commands/scinot.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("scinot")
-        .setDescription("How to read Scientific Notation"),
+	data: new SlashCommandBuilder()
+		.setName('scinot')
+		.setDescription('How to read Scientific Notation'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Switch to Scientific Notation (SciNot for short) in the game settings. An example would be the number after e in your gold.\nIn some guides SciNot is known as Log10. SciNot is eventually forced, and agreed by most to be easier to understand than Standard Notation.\nIn this game, Standard is just a hybrid of written form and SciNot. Each subsequent letter correlates to a multiple of e3. It's much simpler to read and understand the context of 1.845e24 than 1.845 septillion.\nHere's a short video on how to read and convert to and from SciNot: <https://youtu.be/bXkewQ7WEdI>" })
-    }
+		await interaction.reply({
+			content:
+				"Switch to Scientific Notation (SciNot for short) in the game settings. An example would be the number after e in your gold.\nIn some guides SciNot is known as Log10. SciNot is eventually forced, and agreed by most to be easier to understand than Standard Notation.\nIn this game, Standard is just a hybrid of written form and SciNot. Each subsequent letter correlates to a multiple of e3. It's much simpler to read and understand the context of 1.845e24 than 1.845 septillion.\nHere's a short video on how to read and convert to and from SciNot: <https://youtu.be/bXkewQ7WEdI>",
+		});
+	},
 };

--- a/commands/skills.js
+++ b/commands/skills.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("skills")
-        .setDescription("Info on skill usage"),
+	data: new SlashCommandBuilder()
+		.setName('skills')
+		.setDescription('Info on skill usage'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Skills are the mechanic on the right of heroes, providing damage/gold bonuses. Skills are important only toward the end of an ascension when using an active or hybrid build, and should be used as Lucky Strikes(LS)+Golden Clicks(GC)+Energize+Reload(ER) before skills are infinite(cooldown < duration).\nAfter waiting out the duration of the first wave of LS+GC+ER, use all skills for maximum damage and gold gain until you fail a boss or have no more skills to use. Ascend." })
-    }
+		await interaction.reply({
+			content:
+				'Skills are the mechanic on the right of heroes, providing damage/gold bonuses. Skills are important only toward the end of an ascension when using an active or hybrid build, and should be used as Lucky Strikes(LS)+Golden Clicks(GC)+Energize+Reload(ER) before skills are infinite(cooldown < duration).\nAfter waiting out the duration of the first wave of LS+GC+ER, use all skills for maximum damage and gold gain until you fail a boss or have no more skills to use. Ascend.',
+		});
+	},
 };

--- a/commands/skills.js
+++ b/commands/skills.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on skill usage'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Skills are the mechanic on the right of heroes, providing damage/gold bonuses. Skills are important only toward the end of an ascension when using an active or hybrid build, and should be used as Lucky Strikes(LS)+Golden Clicks(GC)+Energize+Reload(ER) before skills are infinite(cooldown < duration).\nAfter waiting out the duration of the first wave of LS+GC+ER, use all skills for maximum damage and gold gain until you fail a boss or have no more skills to use. Ascend.',

--- a/commands/spam.js
+++ b/commands/spam.js
@@ -1,13 +1,13 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("spam")
-        .setDescription("Don't spam"),
+	data: new SlashCommandBuilder().setName('spam').setDescription("Don't spam"),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Do this shit in <#259897497554649098>!" })
-    }
+		await interaction.reply({
+			content: 'Do this shit in <#259897497554649098>!',
+		});
+	},
 };

--- a/commands/spam.js
+++ b/commands/spam.js
@@ -1,11 +1,9 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder().setName('spam').setDescription("Don't spam"),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: 'Do this shit in <#259897497554649098>!',
 		});

--- a/commands/tcc.js
+++ b/commands/tcc.js
@@ -1,13 +1,15 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("tcc")
-        .setDescription("Treasure Chest Chance"),
+	data: new SlashCommandBuilder()
+		.setName('tcc')
+		.setDescription('Treasure Chest Chance'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Treasure Chest Chance. It's usually 1% anyway. No big deal." })
-    }
+		await interaction.reply({
+			content: "Treasure Chest Chance. It's usually 1% anyway. No big deal.",
+		});
+	},
 };

--- a/commands/tcc.js
+++ b/commands/tcc.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Treasure Chest Chance'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: "Treasure Chest Chance. It's usually 1% anyway. No big deal.",
 		});

--- a/commands/thanks bot.js
+++ b/commands/thanks bot.js
@@ -1,14 +1,16 @@
-
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("thanksbot")
-        .setDescription("you're welcome video"),
+	data: new SlashCommandBuilder()
+		.setName('thanksbot')
+		.setDescription("you're welcome video"),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "https://www.youtube.com/watch?v=79DijItQXMM", ephemeral: false })
-    }
-}
+		await interaction.reply({
+			content: 'https://www.youtube.com/watch?v=79DijItQXMM',
+			ephemeral: false,
+		});
+	},
+};

--- a/commands/thanks bot.js
+++ b/commands/thanks bot.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription("you're welcome video"),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: 'https://www.youtube.com/watch?v=79DijItQXMM',
 			ephemeral: false,

--- a/commands/theseancients.js
+++ b/commands/theseancients.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('List of significant ancients to first summon'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Relevant ancients to primarily summon are: Kumawakamaru, Argaiv, Mimzee, Mammon, Atman.\nWhen active, also very important are: Juggernaut, Fragsworth, Bhaal, Pluto\nWith idle, also buy: Siyalatas, Libertas (and Nogardnit if you have an autoclicker, but in that case, active would be recommended)\n\nWhen you have enough HS to summon all ancients, a button appears to do so. It is recommended to use this once you have 1e6 (1M) hero souls.\nUse an [Ancient Calculator](<https://zuils.github.io/ClickerHeroesCalculator/>) to level these ancients.',

--- a/commands/theseancients.js
+++ b/commands/theseancients.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("theseancients")
-        .setDescription("List of significant ancients to first summon"),
+	data: new SlashCommandBuilder()
+		.setName('theseancients')
+		.setDescription('List of significant ancients to first summon'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Relevant ancients to primarily summon are: Kumawakamaru, Argaiv, Mimzee, Mammon, Atman.\nWhen active, also very important are: Juggernaut, Fragsworth, Bhaal, Pluto\nWith idle, also buy: Siyalatas, Libertas (and Nogardnit if you have an autoclicker, but in that case, active would be recommended)\n\nWhen you have enough HS to summon all ancients, a button appears to do so. It is recommended to use this once you have 1e6 (1M) hero souls.\nUse an [Ancient Calculator](<https://zuils.github.io/ClickerHeroesCalculator/>) to level these ancients." })
-    }
+		await interaction.reply({
+			content:
+				'Relevant ancients to primarily summon are: Kumawakamaru, Argaiv, Mimzee, Mammon, Atman.\nWhen active, also very important are: Juggernaut, Fragsworth, Bhaal, Pluto\nWith idle, also buy: Siyalatas, Libertas (and Nogardnit if you have an autoclicker, but in that case, active would be recommended)\n\nWhen you have enough HS to summon all ancients, a button appears to do so. It is recommended to use this once you have 1e6 (1M) hero souls.\nUse an [Ancient Calculator](<https://zuils.github.io/ClickerHeroesCalculator/>) to level these ancients.',
+		});
+	},
 };

--- a/commands/timelapse.js
+++ b/commands/timelapse.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("timelapse")
-        .setDescription("Info on TLs"),
+	data: new SlashCommandBuilder()
+		.setName('timelapse')
+		.setDescription('Info on TLs'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Timelapses (TLs) are a feature that allows you to warp through zones by paying rubies.\nAutoclickers don't click during TLs, hence idle is forced. Their caps are:\n8 hr: 36K zones max, 100 rubies\n24 hr: 108K zones max, 200 rubies\n48hr: 216K zones max, 300 rubies\n168hr: 756K zones max, 500 rubies\n\nTo calculate optimal TLs, and see what zone they should give, use [the TL calc](<https://driej.github.io/Clicker-Heroes-Timelapses/>)" })
-    }
+		await interaction.reply({
+			content:
+				"Timelapses (TLs) are a feature that allows you to warp through zones by paying rubies.\nAutoclickers don't click during TLs, hence idle is forced. Their caps are:\n8 hr: 36K zones max, 100 rubies\n24 hr: 108K zones max, 200 rubies\n48hr: 216K zones max, 300 rubies\n168hr: 756K zones max, 500 rubies\n\nTo calculate optimal TLs, and see what zone they should give, use [the TL calc](<https://driej.github.io/Clicker-Heroes-Timelapses/>)",
+		});
+	},
 };

--- a/commands/timelapse.js
+++ b/commands/timelapse.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on TLs'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Timelapses (TLs) are a feature that allows you to warp through zones by paying rubies.\nAutoclickers don't click during TLs, hence idle is forced. Their caps are:\n8 hr: 36K zones max, 100 rubies\n24 hr: 108K zones max, 200 rubies\n48hr: 216K zones max, 300 rubies\n168hr: 756K zones max, 500 rubies\n\nTo calculate optimal TLs, and see what zone they should give, use [the TL calc](<https://driej.github.io/Clicker-Heroes-Timelapses/>)",

--- a/commands/tp.js
+++ b/commands/tp.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("tp")
-        .setDescription("Info on transcendence power"),
+	data: new SlashCommandBuilder()
+		.setName('tp')
+		.setDescription('Info on transcendence power'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "TP or Transcendence Power is a function in the game that provides exponentially more HS from primal bosses. The TP cap is 25%, it's increased by gaining AS (following `TP = 25-23*e^(-0.0003*AS)`).\nIncreasing TP is essential to get higher zones, it's the main source of HS." })
-    }
+		await interaction.reply({
+			content:
+				"TP or Transcendence Power is a function in the game that provides exponentially more HS from primal bosses. The TP cap is 25%, it's increased by gaining AS (following `TP = 25-23*e^(-0.0003*AS)`).\nIncreasing TP is essential to get higher zones, it's the main source of HS.",
+		});
+	},
 };

--- a/commands/tp.js
+++ b/commands/tp.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Info on transcendence power'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"TP or Transcendence Power is a function in the game that provides exponentially more HS from primal bosses. The TP cap is 25%, it's increased by gaining AS (following `TP = 25-23*e^(-0.0003*AS)`).\nIncreasing TP is essential to get higher zones, it's the main source of HS.",

--- a/commands/trans.js
+++ b/commands/trans.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('When to transcend?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Ascend until you have more HS than last transcension (when transcend for +0 changes into +1 or more, in trans tab).\nThen ascend another 3 times, then transcend.\nThis works until you have ~24% TP, afterwards use [the outsider calc](<https://driej.github.io/Clicker-Heroes-Outsiders/>)',

--- a/commands/trans.js
+++ b/commands/trans.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("trans")
-        .setDescription("When to transcend?"),
+	data: new SlashCommandBuilder()
+		.setName('trans')
+		.setDescription('When to transcend?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Ascend until you have more HS than last transcension (when transcend for +0 changes into +1 or more, in trans tab).\nThen ascend another 3 times, then transcend.\nThis works until you have ~24% TP, afterwards use [the outsider calc](<https://driej.github.io/Clicker-Heroes-Outsiders/>)" })
-    }
+		await interaction.reply({
+			content:
+				'Ascend until you have more HS than last transcension (when transcend for +0 changes into +1 or more, in trans tab).\nThen ascend another 3 times, then transcend.\nThis works until you have ~24% TP, afterwards use [the outsider calc](<https://driej.github.io/Clicker-Heroes-Outsiders/>)',
+		});
+	},
 };

--- a/commands/transcending.js
+++ b/commands/transcending.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Description of transcending'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"Transcendence is the second prestige layer in Clicker Heroes required to progress optimally. It's a step further from ascension in which you lose gilds, ancients, and hero souls, in addition to ascension losses. You gain Ancient Souls (AS), spent on /outsiders, and Transcendent Power (TP), which exponentially raises earned Primal HS. Follow the Outsider calculator in <#207675653091229697> to allocate AS effectively.",

--- a/commands/transcending.js
+++ b/commands/transcending.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("transcending")
-        .setDescription("Description of transcending"),
+	data: new SlashCommandBuilder()
+		.setName('transcending')
+		.setDescription('Description of transcending'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Transcendence is the second prestige layer in Clicker Heroes required to progress optimally. It's a step further from ascension in which you lose gilds, ancients, and hero souls, in addition to ascension losses. You gain Ancient Souls (AS), spent on /outsiders, and Transcendent Power (TP), which exponentially raises earned Primal HS. Follow the Outsider calculator in <#207675653091229697> to allocate AS effectively." })
-    }
+		await interaction.reply({
+			content:
+				"Transcendence is the second prestige layer in Clicker Heroes required to progress optimally. It's a step further from ascension in which you lose gilds, ancients, and hero souls, in addition to ascension losses. You gain Ancient Souls (AS), spent on /outsiders, and Transcendent Power (TP), which exponentially raises earned Primal HS. Follow the Outsider calculator in <#207675653091229697> to allocate AS effectively.",
+		});
+	},
 };

--- a/commands/universaltruth.js
+++ b/commands/universaltruth.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('A universal truth'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({ content: 'People are idiots.' });
 	},
 };

--- a/commands/universaltruth.js
+++ b/commands/universaltruth.js
@@ -1,13 +1,13 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("universaltruth")
-        .setDescription("A universal truth"),
+	data: new SlashCommandBuilder()
+		.setName('universaltruth')
+		.setDescription('A universal truth'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "People are idiots." })
-    }
+		await interaction.reply({ content: 'People are idiots.' });
+	},
 };

--- a/commands/useless.js
+++ b/commands/useless.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Useless present drops'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Presents can drop forge coals, and used to drop bloop coins, both of which are useless.',

--- a/commands/useless.js
+++ b/commands/useless.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("useless")
-        .setDescription("Useless present drops"),
+	data: new SlashCommandBuilder()
+		.setName('useless')
+		.setDescription('Useless present drops'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Presents can drop forge coals, and used to drop bloop coins, both of which are useless." })
-    }
+		await interaction.reply({
+			content:
+				'Presents can drop forge coals, and used to drop bloop coins, both of which are useless.',
+		});
+	},
 };

--- a/commands/v.js
+++ b/commands/v.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Value-level ancients with V'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				"***YOU CAN HOLD 'V' AND CLICK TO LEVEL UP ANCIENTS FASTER!!!***",

--- a/commands/v.js
+++ b/commands/v.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("v")
-        .setDescription("Value-level ancients with V"),
+	data: new SlashCommandBuilder()
+		.setName('v')
+		.setDescription('Value-level ancients with V'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "***YOU CAN HOLD 'V' AND CLICK TO LEVEL UP ANCIENTS FASTER!!!***" })
-    }
+		await interaction.reply({
+			content:
+				"***YOU CAN HOLD 'V' AND CLICK TO LEVEL UP ANCIENTS FASTER!!!***",
+		});
+	},
 };

--- a/commands/whatareclans.js
+++ b/commands/whatareclans.js
@@ -1,13 +1,16 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("whatareclans")
-        .setDescription("Explains basic functionality of clans"),
+	data: new SlashCommandBuilder()
+		.setName('whatareclans')
+		.setDescription('Explains basic functionality of clans'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Clans are the best source of rubies, unlocked after zone 50. Clans allow members to run daily attacks by attacking an “immortal” boss. When your clan defeats the Immortal, everyone earns Rubies and Immortal Souls. You can spend these Souls to level up your class, which increases the damage you deal to the Immortal. Classes are each the same, except a minor damage bonus of 1.25x on days the immortal would be weak to that class.\nClans also have a legacy immortal, giving Hero Souls, but after transcending, this mechanic is rarely useful." })
-    }
+		await interaction.reply({
+			content:
+				'Clans are the best source of rubies, unlocked after zone 50. Clans allow members to run daily attacks by attacking an “immortal” boss. When your clan defeats the Immortal, everyone earns Rubies and Immortal Souls. You can spend these Souls to level up your class, which increases the damage you deal to the Immortal. Classes are each the same, except a minor damage bonus of 1.25x on days the immortal would be weak to that class.\nClans also have a legacy immortal, giving Hero Souls, but after transcending, this mechanic is rarely useful.',
+		});
+	},
 };

--- a/commands/whatareclans.js
+++ b/commands/whatareclans.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Explains basic functionality of clans'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content:
 				'Clans are the best source of rubies, unlocked after zone 50. Clans allow members to run daily attacks by attacking an “immortal” boss. When your clan defeats the Immortal, everyone earns Rubies and Immortal Souls. You can spend these Souls to level up your class, which increases the damage you deal to the Immortal. Classes are each the same, except a minor damage bonus of 1.25x on days the immortal would be weak to that class.\nClans also have a legacy immortal, giving Hero Souls, but after transcending, this mechanic is rarely useful.',

--- a/commands/whereissolomon.js
+++ b/commands/whereissolomon.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Where did solomon go?'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({ content: '404 Ancient Not Found' });
 	},
 };

--- a/commands/whereissolomon.js
+++ b/commands/whereissolomon.js
@@ -1,13 +1,13 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("whereissolomon")
-        .setDescription("Where did solomon go?"),
+	data: new SlashCommandBuilder()
+		.setName('whereissolomon')
+		.setDescription('Where did solomon go?'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "404 Ancient Not Found" })
-    }
+		await interaction.reply({ content: '404 Ancient Not Found' });
+	},
 };

--- a/commands/why.js
+++ b/commands/why.js
@@ -1,13 +1,15 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName("why")
-        .setDescription("Why things are the way they are"),
+	data: new SlashCommandBuilder()
+		.setName('why')
+		.setDescription('Why things are the way they are'),
 
-    async execute(interaction) {
-        const { channel, options } = interaction;
+	async execute(interaction) {
+		const { channel, options } = interaction;
 
-        await interaction.reply({ content: "Because you touch yourself at night." })
-    }
+		await interaction.reply({
+			content: 'Because you touch yourself at night.',
+		});
+	},
 };

--- a/commands/why.js
+++ b/commands/why.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -6,8 +6,6 @@ module.exports = {
 		.setDescription('Why things are the way they are'),
 
 	async execute(interaction) {
-		const { channel, options } = interaction;
-
 		await interaction.reply({
 			content: 'Because you touch yourself at night.',
 		});

--- a/index.js
+++ b/index.js
@@ -326,8 +326,9 @@ function setRole(highestHeroUnlocked, message) {
 }
 
 function decodeSave(data) {
+	let saveData;
 	if (data) {
-		var saveData = Buffer.from(data.slice(32), 'base64');
+		saveData = Buffer.from(data.slice(32), 'base64');
 
 		if (saveData) {
 			try {
@@ -398,16 +399,16 @@ bot.on(Events.MessageCreate, (message) => {
 													'Your save could not be read, be sure to copy the full text of the save file and try again.',
 												);
 											} else {
-												var userBanned = false;
-												var highestHeroUnlocked = getHighestHeroUnlocked(save);
-												var rubies = save.rubies;
-												var gameUID = save.uniqueId;
+												let userBanned = false;
+												const highestHeroUnlocked = getHighestHeroUnlocked(save);
+												const rubies = save.rubies;
+												const gameUID = save.uniqueId;
 
-												var targetMember = bot.guilds.cache
+												const targetMember = bot.guilds.cache
 													.get('104739787872694272')
 													.members.cache.get(message.author.id);
 
-												for (var i = 0; i < JSONsaves.saves.length; i++) {
+												for (let i = 0; i < JSONsaves.saves.length; i++) {
 													if (JSONsaves.saves[i].gameUID) {
 														if (
 															(userBanned === false &&
@@ -420,7 +421,7 @@ bot.on(Events.MessageCreate, (message) => {
 															bannedFromRoles.bannedFromRoles.push(
 																message.author.id,
 															);
-															var edited_bannedFromRoles =
+															const edited_bannedFromRoles =
 																JSON.stringify(bannedFromRoles);
 															fs.writeFileSync(
 																`${__dirname}/bannedFromRoles.json`,
@@ -502,7 +503,7 @@ bot.on(Events.MessageCreate, (message) => {
 				)
 			) {
 				getNumberOfRoles(message.author.id).then((_numRoles) => {
-					var lowercaseMessage = message.content.toLowerCase();
+					const lowercaseMessage = message.content.toLowerCase();
 					if (
 						(lowercaseMessage.includes('@everyone') ||
 							lowercaseMessage.includes('free') ||
@@ -512,8 +513,8 @@ bot.on(Events.MessageCreate, (message) => {
 							lowercaseMessage.includes('nltro')) &&
 						(message.embeds.length > 0 || lowercaseMessage.includes('https:/'))
 					) {
-						var messageContent = message.content;
-						var auditChannel = message.guild.channels.cache.find(
+						const messageContent = message.content;
+						const auditChannel = message.guild.channels.cache.find(
 							(channel) => channel.name === 'audit-log',
 						);
 						message.delete();
@@ -530,7 +531,7 @@ bot.on(Events.MessageCreate, (message) => {
 			}
 
 			if (message.content.toLowerCase().includes('discord.gg')) {
-				var auditChannel = message.guild.channels.cache.find(
+				const auditChannel = message.guild.channels.cache.find(
 					(channel) => channel.name === 'audit-log',
 				);
 				if (memberJoinTime > currentTime - 43200000) {
@@ -556,14 +557,14 @@ bot.on(Events.MessageCreate, (message) => {
 			}
 
 			if (memberJoinTime > currentTime - 43200000) {
-				var autoBanWords = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
-				var auditChannel = message.guild.channels.cache.find(
+				const autoBanWords = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
+				const auditChannel = message.guild.channels.cache.find(
 					(channel) => channel.name === 'audit-log',
 				);
 
-				for (i = 0; i < autoBanWords.length; i++) {
+				for (let i = 0; i < autoBanWords.length; i++) {
 					if (message.content.toLowerCase().includes(autoBanWords[i])) {
-						var messageContent = message.content;
+						const messageContent = message.content;
 						message.delete();
 
 						message.member
@@ -602,11 +603,11 @@ bot.on(Events.MessageCreate, (message) => {
 								)
 							)
 								return;
-							var auditChannel = message.guild.channels.cache.find(
+							const auditChannel = message.guild.channels.cache.find(
 								(channel) => channel.name === 'audit-log',
 							);
 
-							var messageContent = message.content;
+							const messageContent = message.content;
 							message.delete();
 
 							message.member
@@ -629,7 +630,7 @@ bot.on(Events.MessageCreate, (message) => {
 				}
 			}
 
-			var channel = message.channel.id;
+			const channel = message.channel.id;
 			if (channelsPosttedIn[message.author.id]) {
 				const user = channelsPosttedIn[message.author.id];
 				let keys = Object.keys(user);
@@ -642,8 +643,10 @@ bot.on(Events.MessageCreate, (message) => {
 				}
 
 				const messageHistory = [];
-				keys.forEach((key) => messageHistory.push(user[key]));
-				var sortedHistory = messageHistory.sort((a, b) => a - b);
+				for (const key of keys) {
+					messageHistory.push(user[key]);
+				}
+				const sortedHistory = messageHistory.sort((a, b) => a - b);
 				console.log(sortedHistory);
 
 				if (sortedHistory[0] - sortedHistory[3] > -10000) {
@@ -656,7 +659,7 @@ bot.on(Events.MessageCreate, (message) => {
 					)
 						return;
 
-					var auditChannel = message.guild.channels.cache.find(
+					const auditChannel = message.guild.channels.cache.find(
 						(channel) => channel.name === 'audit-log',
 					);
 					message.delete();

--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ const {
 	Events,
 	GatewayIntentBits,
 	Partials,
-	PermissionFlagsBits,
 	PermissionsBitField,
 } = require('discord.js');
 const fs = require('node:fs');
@@ -307,7 +306,6 @@ function setRole(highestHeroUnlocked, message) {
 				'954484630868881421': 'Dorothy',
 			};
 			var roleKeys = Object.keys(roles);
-			var { cache } = guildMember.guild.roles;
 			log('adding role');
 
 			if (highestHeroUnlocked > 0) {
@@ -400,7 +398,8 @@ bot.on(Events.MessageCreate, (message) => {
 												);
 											} else {
 												let userBanned = false;
-												const highestHeroUnlocked = getHighestHeroUnlocked(save);
+												const highestHeroUnlocked =
+													getHighestHeroUnlocked(save);
 												const rubies = save.rubies;
 												const gameUID = save.uniqueId;
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const util = require('util');
 const request = require('request');
 const atob = require('atob');
 require('dotenv').config();
-const Sentry = require("@sentry/node");
+const Sentry = require('@sentry/node');
 const { execSync } = require('child_process');
 
 /**
@@ -11,11 +11,11 @@ const { execSync } = require('child_process');
  * @returns {string|undefined} The latest Git tag or undefined if not found.
  */
 function getGitTag() {
-    try {
-        return execSync('git describe --tags --abbrev=0').toString().trim();
-    } catch (error) {
-        return undefined;
-    }
+	try {
+		return execSync('git describe --tags --abbrev=0').toString().trim();
+	} catch (error) {
+		return undefined;
+	}
 }
 
 if (process.env.SENTRY_DSN) {
@@ -33,30 +33,46 @@ if (process.env.SENTRY_DSN) {
 	console.log('Sentry DSN not provided, Sentry not initialized');
 }
 
-const { DISCORD_TOKEN: token, DISCORD_CLIENT_ID: clientId, DISCORD_GUILD_ID: guildId } = process.env;
+const {
+	DISCORD_TOKEN: token,
+	DISCORD_CLIENT_ID: clientId,
+	DISCORD_GUILD_ID: guildId,
+} = process.env;
 
 if (!token || !clientId || !guildId) {
-    console.error('Missing required environment variables: DISCORD_TOKEN, DISCORD_CLIENT_ID, DISCORD_GUILD_ID');
-    process.exit(1);
+	console.error(
+		'Missing required environment variables: DISCORD_TOKEN, DISCORD_CLIENT_ID, DISCORD_GUILD_ID',
+	);
+	process.exit(1);
 }
-const { REST, Routes, Client, Collection, Events, GatewayIntentBits, Partials, PermissionFlagsBits, PermissionsBitField } = require("discord.js");
-const fs = require("fs");
+const {
+	REST,
+	Routes,
+	Client,
+	Collection,
+	Events,
+	GatewayIntentBits,
+	Partials,
+	PermissionFlagsBits,
+	PermissionsBitField,
+} = require('discord.js');
+const fs = require('fs');
 const path = require('path');
-const JSONbig = require('json-bigint')({ useNativeBigInt: true });;
-const zlib = require("zlib");
+const JSONbig = require('json-bigint')({ useNativeBigInt: true });
+const zlib = require('zlib');
 const bot = new Client({
-    intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.MessageContent,
-        GatewayIntentBits.GuildMembers,
-        GatewayIntentBits.DirectMessages
-    ],
-    partials: [Partials.Channel],
-    allowedMentions: {
-        parse: ['users', 'roles'],
-        repliedUser: true
-    }
+	intents: [
+		GatewayIntentBits.Guilds,
+		GatewayIntentBits.GuildMessages,
+		GatewayIntentBits.MessageContent,
+		GatewayIntentBits.GuildMembers,
+		GatewayIntentBits.DirectMessages,
+	],
+	partials: [Partials.Channel],
+	allowedMentions: {
+		parse: ['users', 'roles'],
+		repliedUser: true,
+	},
 });
 var messageText;
 var userMessageHistory = {};
@@ -66,23 +82,27 @@ bot.commands = new Collection();
 // Grab all the command files from the commands directory you created earlier
 const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const commandFiles = fs
+	.readdirSync(commandsPath)
+	.filter((file) => file.endsWith('.js'));
 
 for (const file of commandFiles) {
-    const filePath = path.join(commandsPath, file);
-    const command = require(filePath);
-    // Set a new item in the Collection with the key as the command name and the value as the exported module
-    if ('data' in command && 'execute' in command) {
-        bot.commands.set(command.data.name, command);
-    } else {
-        console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
-    }
+	const filePath = path.join(commandsPath, file);
+	const command = require(filePath);
+	// Set a new item in the Collection with the key as the command name and the value as the exported module
+	if ('data' in command && 'execute' in command) {
+		bot.commands.set(command.data.name, command);
+	} else {
+		console.log(
+			`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,
+		);
+	}
 }
 
 // Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
 for (const file of commandFiles) {
-    const command = require(`./commands/${file}`);
-    commands.push(command.data.toJSON());
+	const command = require(`./commands/${file}`);
+	commands.push(command.data.toJSON());
 }
 
 // Construct and prepare an instance of the REST module
@@ -90,470 +110,584 @@ const rest = new REST({ version: '10' }).setToken(token);
 
 // and deploy your commands!
 (async () => {
-    try {
-        //console.log(util.inspect(commands.reduce((accumulator, currentValue) => accumulator.concat(currentValue.name), []).sort()))
-        console.log(`Started refreshing ${commands.length} application (/) commands.`);
+	try {
+		//console.log(util.inspect(commands.reduce((accumulator, currentValue) => accumulator.concat(currentValue.name), []).sort()))
+		console.log(
+			`Started refreshing ${commands.length} application (/) commands.`,
+		);
 
-        // The put method is used to fully refresh all commands in the guild with the current set
-        const data = await rest.put(
-            Routes.applicationGuildCommands(clientId, guildId),
-            { body: commands },
-        );
+		// The put method is used to fully refresh all commands in the guild with the current set
+		const data = await rest.put(
+			Routes.applicationGuildCommands(clientId, guildId),
+			{ body: commands },
+		);
 
-        console.log(`Successfully reloaded ${data.length} application (/) commands.`);
-    } catch (error) {
-        // And of course, make sure you catch and log any errors!
-        console.error(error);
-    }
+		console.log(
+			`Successfully reloaded ${data.length} application (/) commands.`,
+		);
+	} catch (error) {
+		// And of course, make sure you catch and log any errors!
+		console.error(error);
+	}
 })();
 
 var JSONsaves;
 var JSONBannedsaves;
 var bannedFromRoles;
 
-setInterval(function () {
-    log("writing to files");
-    fs.writeFileSync(__dirname + '/saves.json', JSON.stringify(JSONsaves));
-    fs.writeFileSync(__dirname + '/bannedSaves.json', JSON.stringify(JSONBannedsaves));
-}, 1000 * 60 * 5)
-
+setInterval(
+	() => {
+		log('writing to files');
+		fs.writeFileSync(__dirname + '/saves.json', JSON.stringify(JSONsaves));
+		fs.writeFileSync(
+			__dirname + '/bannedSaves.json',
+			JSON.stringify(JSONBannedsaves),
+		);
+	},
+	1000 * 60 * 5,
+);
 
 fs.readFile(__dirname + '/saves.json', (err, data) => {
-    if (err) throw err;
-    JSONsaves = JSON.parse(data);
+	if (err) throw err;
+	JSONsaves = JSON.parse(data);
 });
 
 fs.readFile(__dirname + '/bannedSaves.json', (err, data) => {
-    if (err) throw err;
-    JSONBannedsaves = JSON.parse(data);
+	if (err) throw err;
+	JSONBannedsaves = JSON.parse(data);
 });
 
 fs.readFile(__dirname + '/bannedFromRoles.json', (err, data) => {
-    if (err) throw err;
-    bannedFromRoles = JSON.parse(data);
+	if (err) throw err;
+	bannedFromRoles = JSON.parse(data);
 });
 
-bot.on(Events.InteractionCreate, async interaction => {
-    if (interaction.isChatInputCommand() && !interaction.isAutocomplete()) {
-        const command = interaction.client.commands.get(interaction.commandName);
+bot.on(Events.InteractionCreate, async (interaction) => {
+	if (interaction.isChatInputCommand() && !interaction.isAutocomplete()) {
+		const command = interaction.client.commands.get(interaction.commandName);
 
-        if (!command) {
-            console.error(`No command matching ${interaction.commandName} was found.`);
-            return;
-        }
+		if (!command) {
+			console.error(
+				`No command matching ${interaction.commandName} was found.`,
+			);
+			return;
+		}
 
-        try {
-            await command.execute(interaction);
-        } catch (error) {
-            console.error(error);
-            await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
-        }
-    }
-    else if (interaction.isAutocomplete()) {
-        const command = interaction.client.commands.get(interaction.commandName);
+		try {
+			await command.execute(interaction);
+		} catch (error) {
+			console.error(error);
+			await interaction.reply({
+				content: 'There was an error while executing this command!',
+				ephemeral: true,
+			});
+		}
+	} else if (interaction.isAutocomplete()) {
+		const command = interaction.client.commands.get(interaction.commandName);
 
-        if (!command) {
-            console.error(`No command matching ${interaction.commandName} was found.`);
-            return;
-        }
-        try {
-            await command.autoComplete(interaction);
-        } catch (error) {
-            console.error(error);
-            await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
-        }
-    }
+		if (!command) {
+			console.error(
+				`No command matching ${interaction.commandName} was found.`,
+			);
+			return;
+		}
+		try {
+			await command.autoComplete(interaction);
+		} catch (error) {
+			console.error(error);
+			await interaction.reply({
+				content: 'There was an error while executing this command!',
+				ephemeral: true,
+			});
+		}
+	}
 });
 
 function log(log) {
-    var time = new Date();
-    console.log("[" + (time.getHours() % 12) + ":" + time.getMinutes() + ":" + time.getSeconds() + "] " + log);
+	var time = new Date();
+	console.log(
+		'[' +
+			(time.getHours() % 12) +
+			':' +
+			time.getMinutes() +
+			':' +
+			time.getSeconds() +
+			'] ' +
+			log,
+	);
 }
 
 function getRoles() {
-    return new Promise((res, rej) => {
-        res(bot.guilds.cache.get(guildId).roles);
-    });
+	return new Promise((res, rej) => {
+		res(bot.guilds.cache.get(guildId).roles);
+	});
 }
 
 function getGuildMember(userID) {
-    return new Promise((res, rej) => {
-        res(bot.guilds.cache.get(guildId).members.fetch(userID));
-    });
+	return new Promise((res, rej) => {
+		res(bot.guilds.cache.get(guildId).members.fetch(userID));
+	});
 }
 
 function getNumberOfRoles(userID) {
-    return new Promise((res, rej) => {
-        res(getGuildMember(userID)
-            .then((member) => {
-                var numRoles = member.roles.cache
-                    .map((role) => role.toString());
-                return numRoles.length;
-            }));
-    });
+	return new Promise((res, rej) => {
+		res(
+			getGuildMember(userID).then((member) => {
+				var numRoles = member.roles.cache.map((role) => role.toString());
+				return numRoles.length;
+			}),
+		);
+	});
 }
 
 function getHighestHeroUnlocked(data) {
-    let saveObject = JSON.parse(data);
-    let heroes = saveObject.heroCollection.heroes
-    let objectKeys = Object.keys(heroes);
-    let currentHighestValue = 0;
+	const saveObject = JSON.parse(data);
+	const heroes = saveObject.heroCollection.heroes;
+	const objectKeys = Object.keys(heroes);
+	let currentHighestValue = 0;
 
-    objectKeys.forEach(hero => {
-        if (heroes[hero].level > 0) currentHighestValue = hero;
-    })
+	objectKeys.forEach((hero) => {
+		if (heroes[hero].level > 0) currentHighestValue = hero;
+	});
 
-    return currentHighestValue;
+	return currentHighestValue;
 }
 
 function setRole(highestHeroUnlocked, message) {
-    let userID = message.author.id;
+	const userID = message.author.id;
 
-    if (bannedFromRoles.bannedFromRoles.includes(userID)) return;
-    getGuildMember(userID)
-        .then(guildMember => {
-            var rollAdded = false;
-            var roles = {
-                "954478762609770558": "Cid",
-                "954478916037390377": "Treebeast",
-                "954479042189488148": "Ivan",
-                "954479205205291018": "Brittany",
-                "954503656806416384": "Fisherman",
-                "954479315481931817": "Betty",
-                "954479514824622200": "Samurai",
-                "954479682991050773": "Leon",
-                "954479826306215946": "Forest Seer",
-                "954479940525514782": "Alexa",
-                "954480031508340756": "Natalia",
-                "954480252904685598": "Mercedes",
-                "954480412846092298": "Bobby",
-                "954480498518929529": "Broyle",
-                "954480578315563008": "Sir George II",
-                "954480673027158016": "King Midas",
-                "954480842124701747": "Referi Jerator",
-                "954480982713585704": "Abaddon",
-                "954481096903516200": "Ma Zhu",
-                "954481186615459840": "Amenhotep",
-                "954481276860104804": "Beastlord",
-                "954481370112081931": "Athena",
-                "954481448226803724": "Aphrodite",
-                "954481585774821418": "Shinatobe",
-                "954481700220600320": "Grant",
-                "954481771087527966": "Frostleaf",
-                "954481841111445535": "Dread Knight",
-                "954481917686866061": "Atlas",
-                "954481993528258600": "Terra",
-                "954482077535985734": "Phthalo",
-                "954482150009372802": "Orntchya",
-                "954482335867363439": "Lilin",
-                "954482437990281227": "Cadmia",
-                "954482614629175346": "Alabaster",
-                "954482788608901181": "Astraea",
-                "954482883492454400": "Chiron",
-                "954504616538697769": "Moloch",
-                "954482966480969808": "Bomber Max",
-                "954483061205123172": "Gog",
-                "954483163105734747": "Wepwawet",
-                "954483239597260971": "Tsuchi",
-                "954483392597073980": "Skogur",
-                "954483519269249084": "Moeru",
-                "954483641180889098": "Zilar",
-                "954483717169086524": "Madzi",
-                "954483982609842186": "Xavira",
-                "954484076750991431": "Cadu",
-                "954484161912119316": "Ceus",
-                "954484216203182240": "The Maw",
-                "954484291172175953": "Yachiyl",
-                "954484414140780604": "Rose",
-                "954484508579733514": "Sophia",
-                "954484562874990614": "Blanche",
-                "954484630868881421": "Dorothy"
-            }
-            var roleKeys = Object.keys(roles);
-            var { cache } = guildMember.guild.roles;
-            log("adding role")
+	if (bannedFromRoles.bannedFromRoles.includes(userID)) return;
+	getGuildMember(userID)
+		.then((guildMember) => {
+			var rollAdded = false;
+			var roles = {
+				'954478762609770558': 'Cid',
+				'954478916037390377': 'Treebeast',
+				'954479042189488148': 'Ivan',
+				'954479205205291018': 'Brittany',
+				'954503656806416384': 'Fisherman',
+				'954479315481931817': 'Betty',
+				954479514824622200: 'Samurai',
+				'954479682991050773': 'Leon',
+				'954479826306215946': 'Forest Seer',
+				'954479940525514782': 'Alexa',
+				'954480031508340756': 'Natalia',
+				'954480252904685598': 'Mercedes',
+				'954480412846092298': 'Bobby',
+				'954480498518929529': 'Broyle',
+				'954480578315563008': 'Sir George II',
+				'954480673027158016': 'King Midas',
+				'954480842124701747': 'Referi Jerator',
+				'954480982713585704': 'Abaddon',
+				954481096903516200: 'Ma Zhu',
+				'954481186615459840': 'Amenhotep',
+				'954481276860104804': 'Beastlord',
+				'954481370112081931': 'Athena',
+				'954481448226803724': 'Aphrodite',
+				'954481585774821418': 'Shinatobe',
+				'954481700220600320': 'Grant',
+				'954481771087527966': 'Frostleaf',
+				'954481841111445535': 'Dread Knight',
+				'954481917686866061': 'Atlas',
+				954481993528258600: 'Terra',
+				'954482077535985734': 'Phthalo',
+				'954482150009372802': 'Orntchya',
+				'954482335867363439': 'Lilin',
+				'954482437990281227': 'Cadmia',
+				'954482614629175346': 'Alabaster',
+				'954482788608901181': 'Astraea',
+				954482883492454400: 'Chiron',
+				'954504616538697769': 'Moloch',
+				'954482966480969808': 'Bomber Max',
+				'954483061205123172': 'Gog',
+				'954483163105734747': 'Wepwawet',
+				'954483239597260971': 'Tsuchi',
+				'954483392597073980': 'Skogur',
+				'954483519269249084': 'Moeru',
+				'954483641180889098': 'Zilar',
+				'954483717169086524': 'Madzi',
+				'954483982609842186': 'Xavira',
+				'954484076750991431': 'Cadu',
+				'954484161912119316': 'Ceus',
+				'954484216203182240': 'The Maw',
+				'954484291172175953': 'Yachiyl',
+				'954484414140780604': 'Rose',
+				'954484508579733514': 'Sophia',
+				'954484562874990614': 'Blanche',
+				'954484630868881421': 'Dorothy',
+			};
+			var roleKeys = Object.keys(roles);
+			var { cache } = guildMember.guild.roles;
+			log('adding role');
 
-            if (highestHeroUnlocked > 0) {
-                guildMember.roles.add(roleKeys[highestHeroUnlocked - 1]);
-                rollAdded = true;
-            }
+			if (highestHeroUnlocked > 0) {
+				guildMember.roles.add(roleKeys[highestHeroUnlocked - 1]);
+				rollAdded = true;
+			}
 
-            if (rollAdded) {
-                message.reply("You have been assigned a role on the Clicker Heroes Discord. Post a message in chat to see it.");
-                log("added role");
-            }
-
-        }).catch(console.error);
+			if (rollAdded) {
+				message.reply(
+					'You have been assigned a role on the Clicker Heroes Discord. Post a message in chat to see it.',
+				);
+				log('added role');
+			}
+		})
+		.catch(console.error);
 }
 
 function decodeSave(data) {
+	if (data) {
+		var saveData = Buffer.from(data.slice(32), 'base64');
 
-    if (data) {
-        var saveData = Buffer.from(data.slice(32), 'base64');
+		if (saveData) {
+			try {
+				if (data.startsWith('7a990')) {
+					saveData = zlib.inflateSync(saveData).toString();
+				} else if (data.startsWith('7e8bb')) {
+					saveData = zlib.inflateRawSync(saveData).toString();
+				}
+			} catch {
+				saveData = 'FAILURE';
+			}
 
-        if (saveData) {
-            try {
-                if (data.startsWith("7a990")) {
-                    saveData = zlib.inflateSync(saveData).toString();
-                }
-                else if (data.startsWith("7e8bb")) {
-                    saveData = zlib.inflateRawSync(saveData).toString();
-                }
-            }
-            catch {
-                saveData = 'FAILURE';
-            }
-
-            return saveData;
-        }
-    }
+			return saveData;
+		}
+	}
 }
 
-
-bot.once(Events.ClientReady, c => {
-    log(`${c.user.username} is online!`);
+bot.once(Events.ClientReady, (c) => {
+	log(`${c.user.username} is online!`);
 });
 
+bot.on(Events.MessageCreate, (message) => {
+	if (message.author.bot) return;
+	var memberJoinTime;
 
-bot.on(Events.MessageCreate, message => {
-    if (message.author.bot) return;
-    var memberJoinTime;
+	if (message.member) {
+		memberJoinTime = message.member.joinedTimestamp;
+	}
 
-    if (message.member) {
-        memberJoinTime = message.member.joinedTimestamp;
-    };
+	var currentTime = Date.now();
 
-    var currentTime = Date.now();
+	//DM REQUESTING SAVE CODE
+	if (message.channel.isDMBased()) {
+		if (bannedFromRoles.bannedFromRoles.includes(message.author.id)) {
+			message.reply(
+				'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
+			);
+		} else {
+			if (bannedFromRoles.bannedFromRoles.includes(message.author.id)) {
+				message.reply(
+					'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
+				);
+			} else {
+				log('received DM');
+				if (message.attachments.first()) {
+					const name = message.attachments.first().name;
+					if (name.includes('.txt')) {
+						const uploadDir = path.join(__dirname, 'uploads');
+						if (!fs.existsSync(uploadDir)) {
+							fs.mkdirSync(uploadDir);
+						}
 
-    //DM REQUESTING SAVE CODE
-    if (message.channel.isDMBased()) {
-        if (bannedFromRoles.bannedFromRoles.includes(message.author.id)) {
-            message.reply("Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.");
-        }
-        else {
-            if (bannedFromRoles.bannedFromRoles.includes(message.author.id)) {
-                message.reply("Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.");
-            }
-            else {
-                log("received DM");
-                if (message.attachments.first()) {
-                    let name = message.attachments.first().name;
-                    if (name.includes('.txt')) {
-                        const uploadDir = path.join(__dirname, 'uploads');
-                        if (!fs.existsSync(uploadDir)) {
-                            fs.mkdirSync(uploadDir);
-                        }
+						request
+							.get(message.attachments.first().url)
+							.on('error', console.error)
+							.pipe(fs.createWriteStream(path.join(uploadDir, name)))
+							.on('finish', () => {
+								fs.readFile(path.join(uploadDir, name), 'utf8', (err, data) => {
+									var save = '';
 
-                        request.get(message.attachments.first().url)
-                            .on('error', console.error)
-                            .pipe(fs.createWriteStream(path.join(uploadDir, name)))
-                            .on('finish', function () {
-                                fs.readFile(path.join(uploadDir, name), "utf8", (err, data) => {
-                                    var save = ""
+									if (data.includes('7a990') || data.includes('7e8bb')) {
+										save = decodeSave(data);
+										if (save == 'FAILURE') {
+											message.reply(
+												'Your save could not be read, be sure to copy the full text of the save file and try again.',
+											);
+										} else {
+											var userBanned = false;
+											var highestHeroUnlocked = getHighestHeroUnlocked(save);
+											var rubies = save.rubies;
+											var gameUID = save.uniqueId;
 
-                                    if (data.includes("7a990") || data.includes("7e8bb")) {
-                                        save = decodeSave(data);
-                                        if (save == "FAILURE") {
-                                            message.reply("Your save could not be read, be sure to copy the full text of the save file and try again.")
-                                        }
-                                        else {
-                                            var userBanned = false;
-                                            var highestHeroUnlocked = getHighestHeroUnlocked(save);
-                                            var rubies = save.rubies;
-                                            var gameUID = save.uniqueId;
+											var targetMember = bot.guilds.cache
+												.get('104739787872694272')
+												.members.cache.get(message.author.id);
 
-                                            var targetMember = bot.guilds.cache.get("104739787872694272").members.cache.get(message.author.id);
+											for (var i = 0; i < JSONsaves['saves'].length; i++) {
+												if (JSONsaves['saves'][i].gameUID) {
+													if (
+														(userBanned == false &&
+															JSONsaves['saves'][i].gameUID == gameUID &&
+															JSONsaves['saves'][i].userID !=
+																message.author.id) ||
+														rubies > 15000
+													) {
+														userBanned = true;
+														bannedFromRoles.bannedFromRoles.push(
+															message.author.id,
+														);
+														var edited_bannedFromRoles =
+															JSON.stringify(bannedFromRoles);
+														fs.writeFileSync(
+															__dirname + '/bannedFromRoles.json',
+															edited_bannedFromRoles,
+														);
+														message.reply(
+															'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
+														);
 
-                                            for (var i = 0; i < JSONsaves['saves'].length; i++) {
-                                                if (JSONsaves['saves'][i].gameUID) {
-                                                    if (userBanned == false && (JSONsaves['saves'][i].gameUID == gameUID && JSONsaves['saves'][i].userID != message.author.id) || rubies > 15000) {
-                                                        userBanned = true;
-                                                        bannedFromRoles.bannedFromRoles.push(message.author.id);
-                                                        var edited_bannedFromRoles = JSON.stringify(bannedFromRoles);
-                                                        fs.writeFileSync(__dirname + '/bannedFromRoles.json', edited_bannedFromRoles);
-                                                        message.reply("Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.");
+														if (targetMember) {
+															targetMember.roles.set([]);
+														}
+													}
+												}
+											}
 
-                                                        if (targetMember) {
-                                                            targetMember.roles.set([]);
-                                                        }
-                                                    }
-                                                }
-                                            }
+											if (
+												userBanned == false &&
+												!bannedFromRoles.bannedFromRoles.includes(
+													message.author.id,
+												)
+											) {
+												JSONsaves['saves'].push({
+													userID: message.author.id,
+													gameUID: gameUID,
+													save: data,
+												});
+											} else {
+												JSONBannedsaves['saves'].push({
+													userID: message.author.id,
+													gameUID: gameUID,
+													userBanned: userBanned,
+													save: data,
+												});
+											}
+											setRole(highestHeroUnlocked, message);
+										}
+									}
+								});
 
-                                            if (userBanned == false && !bannedFromRoles.bannedFromRoles.includes(message.author.id)) {
-                                                JSONsaves['saves'].push({ "userID": message.author.id, "gameUID": gameUID, "save": data });
-                                            }
-                                            else {
-                                                JSONBannedsaves['saves'].push({ "userID": message.author.id, "gameUID": gameUID, "userBanned": userBanned, "save": data });
-                                            }
-                                            setRole(highestHeroUnlocked, message);
-                                        }
-                                    }
-                                });
+								fs.unlink(path.join(uploadDir, name), (err) => {
+									if (err) console.error('Failed to clean up upload:', err);
+								});
+							});
+					}
+				}
+			}
+		}
+	}
 
-                                fs.unlink(path.join(uploadDir, name), err => {
-                                    if (err) console.error('Failed to clean up upload:', err);
-                                });
-                            });
-                    }
-                }
-            }
-        }
-    }
+	if (
+		message.channel.id == 104740000591024128 &&
+		!message.content.toLowerCase().startsWith('recruiting:')
+	) {
+		log(message.content);
+		if (
+			!message.member.permissions.has(PermissionsBitField.Flags.ManageMessages)
+		) {
+			const messageText = `<@${message.member.id}> Hey, it appears you posted in <#104740000591024128> without proper format or posted a non recruitment post.\n<#104740000591024128> is only for clans actively searching for members. If you are looking for a clan reach out to the clan leaders who have posted there.\nIf your post was a recruitment post, make sure to start it with "Recruiting:"`;
+			message.member
+				.send(messageText + '\n\n Message Copy: ' + message.content)
+				.catch(() => {
+					var channel = bot.channels.cache.get('260159911822884866');
+					channel.send(messageText);
+				});
 
-    if (message.channel.id == 104740000591024128 && !message.content.toLowerCase().startsWith("recruiting:")) {
-        log(message.content);
-        if (!message.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
+			message.delete();
+		}
+	}
 
-            let messageText = `<@${message.member.id}> Hey, it appears you posted in <#104740000591024128> without proper format or posted a non recruitment post.\n<#104740000591024128> is only for clans actively searching for members. If you are looking for a clan reach out to the clan leaders who have posted there.\nIf your post was a recruitment post, make sure to start it with "Recruiting:"`
-            message.member.send(messageText + "\n\n Message Copy: " + message.content)
-                .catch(() => {
-                    var channel = bot.channels.cache.get("260159911822884866")
-                    channel.send(messageText);
-                })
+	//Auto mod stuff
 
-            message.delete();
-        }
-    }
+	if (!message.channel.isDMBased()) {
+		if (message.guild.id == guildId) {
+			if (
+				!message.member.permissions.has(
+					PermissionsBitField.Flags.ManageMessages,
+				)
+			) {
+				getNumberOfRoles(message.author.id).then((numRoles) => {
+					var lowercaseMessage = message.content.toLowerCase();
+					if (
+						(lowercaseMessage.includes('@everyone') ||
+							lowercaseMessage.includes('free') ||
+							lowercaseMessage.includes('steam') ||
+							lowercaseMessage.includes('airdrop')) &&
+						(lowercaseMessage.includes('nitro') ||
+							lowercaseMessage.includes('nltro')) &&
+						(message.embeds.length > 0 || lowercaseMessage.includes('https:/'))
+					) {
+						var messageContent = message.content;
+						var auditChannel = message.guild.channels.cache.find(
+							(channel) => channel.name === 'audit-log',
+						);
+						message.delete();
+						message.member
+							.ban({ days: 7, reason: 'posting nitro scam' })
+							.then(console.log)
+							.catch(console.error);
 
-    //Auto mod stuff
+						auditChannel.send({
+							content: `Banned <@${message.member.id}> for posting nitro scam. Message content: \`\`\`${messageContent}\`\`\``,
+						});
+					}
+				});
+			}
 
+			if (message.content.toLowerCase().includes('discord.gg')) {
+				var auditChannel = message.guild.channels.cache.find(
+					(channel) => channel.name === 'audit-log',
+				);
+				if (memberJoinTime > currentTime - 43200000) {
+					message.delete();
+					log('Link posted by ' + message.author.username);
+					message.member
+						.send('Do not post links to other Discord Servers')
+						.then(console.log)
+						.catch(console.error);
 
+					auditChannel.send({
+						contnet: `Warned <@${message.member.id}> for posting links to a different Discord server.`,
+					});
+				}
+			}
 
+			if (
+				message.content.includes(
+					'Checkout this game I am playing https://play.google.com',
+				)
+			) {
+				message.delete();
+			}
 
-    if (!message.channel.isDMBased()) {
-        if (message.guild.id == guildId) {
-            if (!message.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) {
-                getNumberOfRoles(message.author.id)
-                    .then((numRoles) => {
-                        var lowercaseMessage = message.content.toLowerCase();
-                        if ((lowercaseMessage.includes("@everyone") || lowercaseMessage.includes("free") || lowercaseMessage.includes("steam") || lowercaseMessage.includes("airdrop")) && (lowercaseMessage.includes("nitro") || lowercaseMessage.includes("nltro")) && (message.embeds.length > 0 || lowercaseMessage.includes("https:/"))) {
-                            var messageContent = message.content;
-                            var auditChannel = message.guild.channels.cache.find(channel => channel.name === "audit-log");
-                            message.delete();
-                            message.member.ban({ days: 7, reason: 'posting nitro scam' })
-                                .then(console.log)
-                                .catch(console.error);
+			if (memberJoinTime > currentTime - 43200000) {
+				var autoBanWords = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
+				var auditChannel = message.guild.channels.cache.find(
+					(channel) => channel.name === 'audit-log',
+				);
 
-                            auditChannel.send({ content: `Banned <@${message.member.id}> for posting nitro scam. Message content: \`\`\`${messageContent}\`\`\`` })
-                        }
-                    });
-            }
+				for (i = 0; i < autoBanWords.length; i++) {
+					if (message.content.toLowerCase().includes(autoBanWords[i])) {
+						var messageContent = message.content;
+						message.delete();
 
-            if (message.content.toLowerCase().includes("discord.gg")) {
-                var auditChannel = message.guild.channels.cache.find(channel => channel.name === "audit-log");
-                if (memberJoinTime > currentTime - 43200000) {
-                    message.delete();
-                    log("Link posted by " + message.author.username);
-                    message.member.send("Do not post links to other Discord Servers")
-                        .then(console.log)
-                        .catch(console.error);
+						message.member
+							.send(
+								'You have been banned from the Clicker Heroes Discord for posting racist comments.',
+							)
+							.then(console.log)
+							.catch(console.error);
 
-                    auditChannel.send({ contnet: `Warned <@${message.member.id}> for posting links to a different Discord server.` })
-                }
-            }
+						message.member
+							.ban({ days: 7, reason: 'Posted racist comments' })
+							.then(console.log)
+							.catch(console.error);
 
-            if (message.content.includes("Checkout this game I am playing https://play.google.com")) {
-                message.delete();
-            }
+						auditChannel.send({
+							content: `Banned <@${message.member.id}> for posting racist comments. Message content: \`\`\`${messageContent}\`\`\``,
+						});
+					}
+				}
 
-            if (memberJoinTime > currentTime - 43200000) {
-                var autoBanWords = ["nigger", "nigga", "jew", "n1gger", "n!gger"];
-                var auditChannel = message.guild.channels.cache.find(channel => channel.name === "audit-log");
+				if (userMessageHistory[message.author.id]) {
+					userMessageHistory[message.author.id].push(currentTime);
 
-                for (i = 0; i < autoBanWords.length; i++) {
-                    if (message.content.toLowerCase().includes(autoBanWords[i])) {
-                        var messageContent = message.content;
-                        message.delete();
+					if (userMessageHistory[message.author.id].length > 6) {
+						userMessageHistory[message.author.id] =
+							userMessageHistory[message.author.id].slice(-6);
 
-                        message.member.send("You have been banned from the Clicker Heroes Discord for posting racist comments.")
-                            .then(console.log)
-                            .catch(console.error);
+						if (
+							userMessageHistory[message.author.id][0] -
+								userMessageHistory[message.author.id][5] >
+							-8000
+						) {
+							if (
+								message.member.permissions.has(
+									PermissionsBitField.Flags.ManageMessages,
+								)
+							)
+								return;
+							var auditChannel = message.guild.channels.cache.find(
+								(channel) => channel.name === 'audit-log',
+							);
 
-                        message.member.ban({ days: 7, reason: 'Posted racist comments' })
-                            .then(console.log)
-                            .catch(console.error);
+							var messageContent = message.content;
+							message.delete();
 
+							message.member
+								.send('You have been banned for spamming')
+								.then(console.log)
+								.catch(console.error);
 
-                        auditChannel.send({ content: `Banned <@${message.member.id}> for posting racist comments. Message content: \`\`\`${messageContent}\`\`\`` })
-                    }
-                }
+							message.member
+								.ban({ days: 7, reason: 'spamming' })
+								.then(console.log)
+								.catch(console.error);
 
-                if (userMessageHistory[message.author.id]) {
-                    userMessageHistory[message.author.id].push(currentTime);
+							auditChannel.send({
+								content: `Banned <@${message.member.id}> for spamming (posting 6 messages within 8 seconds) Message content: \`\`\`${messageContent}\`\`\``,
+							});
+						}
+					}
+				} else {
+					userMessageHistory[message.author.id] = [currentTime];
+				}
+			}
 
-                    if (userMessageHistory[message.author.id].length > 6) {
-                        userMessageHistory[message.author.id] = userMessageHistory[message.author.id].slice(-6);
+			var channel = message.channel.id;
+			if (channelsPosttedIn[message.author.id]) {
+				const user = channelsPosttedIn[message.author.id];
+				let keys = Object.keys(user);
 
-                        if (userMessageHistory[message.author.id][0] - userMessageHistory[message.author.id][5] > -8000) {
-                            if (message.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) return;
-                            var auditChannel = message.guild.channels.cache.find(channel => channel.name === "audit-log");
+				user[channel] = currentTime;
 
-                            var messageContent = message.content;
-                            message.delete();
+				if (keys.length > 3) {
+					delete user[keys[0]];
+					keys = Object.keys(user);
+				}
 
-                            message.member.send("You have been banned for spamming")
-                                .then(console.log)
-                                .catch(console.error);
+				const messageHistory = [];
+				keys.forEach((key) => messageHistory.push(user[key]));
+				var sortedHistory = messageHistory.sort((a, b) => a - b);
+				console.log(sortedHistory);
 
-                            message.member.ban({ days: 7, reason: 'spamming' })
-                                .then(console.log)
-                                .catch(console.error);
+				if (sortedHistory[0] - sortedHistory[3] > -10000) {
+					console.log('posting too fast');
 
-                            auditChannel.send({ content: `Banned <@${message.member.id}> for spamming (posting 6 messages within 8 seconds) Message content: \`\`\`${messageContent}\`\`\`` })
-                        }
-                    }
-                }
-                else {
-                    userMessageHistory[message.author.id] = [currentTime];
-                }
-            }
+					if (
+						message.member.permissions.has(
+							PermissionsBitField.Flags.ManageMessages,
+						)
+					)
+						return;
 
-            var channel = message.channel.id;
-            if (channelsPosttedIn[message.author.id]) {
-                let user = channelsPosttedIn[message.author.id];
-                let keys = Object.keys(user);
+					var auditChannel = message.guild.channels.cache.find(
+						(channel) => channel.name === 'audit-log',
+					);
+					message.delete();
 
-                user[channel] = currentTime;
+					message.member
+						.send('You have been banned for spamming')
+						.then(console.log)
+						.catch(console.error);
 
-                if (keys.length > 3) {
-                    delete user[keys[0]];
-                    keys = Object.keys(user);
-                }
+					message.member
+						.ban({ days: 7, reason: 'spamming' })
+						.then(console.log)
+						.catch(console.error);
 
-                let messageHistory = [];
-                keys.forEach(key => messageHistory.push(user[key]));
-                var sortedHistory = messageHistory.sort((a, b) => a - b);
-                console.log(sortedHistory);
-
-                if (sortedHistory[0] - sortedHistory[3] > -10000) {
-                    console.log("posting too fast");
-
-                    if (message.member.permissions.has(PermissionsBitField.Flags.ManageMessages)) return;
-
-                    var auditChannel = message.guild.channels.cache.find(channel => channel.name === "audit-log");
-                    message.delete();
-
-                    message.member.send("You have been banned for spamming")
-                        .then(console.log)
-                        .catch(console.error);
-
-                    message.member.ban({ days: 7, reason: 'spamming' })
-                        .then(console.log)
-                        .catch(console.error);
-
-                    auditChannel.send({ content: `Banned <@${message.member.id}> for spamming (posting to 4 different channels within 10 seconds). Message content: \`\`\`${message.content}\`\`\`` })
-                }
-            }
-            else {
-                channelsPosttedIn[message.author.id] = { [channel]: currentTime };
-            }
-        }
-    }
+					auditChannel.send({
+						content: `Banned <@${message.member.id}> for spamming (posting to 4 different channels within 10 seconds). Message content: \`\`\`${message.content}\`\`\``,
+					});
+				}
+			} else {
+				channelsPosttedIn[message.author.id] = { [channel]: currentTime };
+			}
+		}
+	}
 });
 
-
-bot.on('error', console.error)
+bot.on('error', console.error);
 
 bot.login(token);
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
                 "dotenv": "^16.0.0",
                 "json-bigint": "^1.0.0",
                 "request": "^2.88.2"
+            },
+            "devDependencies": {
+                "@biomejs/biome": "^2.3.6"
             }
         },
         "node_modules/@apm-js-collab/code-transformer": {
@@ -32,6 +35,169 @@
                 "@apm-js-collab/code-transformer": "^0.8.0",
                 "debug": "^4.4.1",
                 "module-details-from-path": "^1.0.4"
+            }
+        },
+        "node_modules/@biomejs/biome": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
+            "integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "bin": {
+                "biome": "bin/biome"
+            },
+            "engines": {
+                "node": ">=14.21.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/biome"
+            },
+            "optionalDependencies": {
+                "@biomejs/cli-darwin-arm64": "2.3.6",
+                "@biomejs/cli-darwin-x64": "2.3.6",
+                "@biomejs/cli-linux-arm64": "2.3.6",
+                "@biomejs/cli-linux-arm64-musl": "2.3.6",
+                "@biomejs/cli-linux-x64": "2.3.6",
+                "@biomejs/cli-linux-x64-musl": "2.3.6",
+                "@biomejs/cli-win32-arm64": "2.3.6",
+                "@biomejs/cli-win32-x64": "2.3.6"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
+            "integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
+            "integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
+            "integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64-musl": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
+            "integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
+            "integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64-musl": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
+            "integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
+            "integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
+            "integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
             }
         },
         "node_modules/@discordjs/builders": {
@@ -1833,6 +1999,78 @@
                 "debug": "^4.4.1",
                 "module-details-from-path": "^1.0.4"
             }
+        },
+        "@biomejs/biome": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
+            "integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
+            "dev": true,
+            "requires": {
+                "@biomejs/cli-darwin-arm64": "2.3.6",
+                "@biomejs/cli-darwin-x64": "2.3.6",
+                "@biomejs/cli-linux-arm64": "2.3.6",
+                "@biomejs/cli-linux-arm64-musl": "2.3.6",
+                "@biomejs/cli-linux-x64": "2.3.6",
+                "@biomejs/cli-linux-x64-musl": "2.3.6",
+                "@biomejs/cli-win32-arm64": "2.3.6",
+                "@biomejs/cli-win32-x64": "2.3.6"
+            }
+        },
+        "@biomejs/cli-darwin-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
+            "integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-darwin-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
+            "integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
+            "integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64-musl": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
+            "integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
+            "integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64-musl": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
+            "integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-arm64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
+            "integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-x64": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
+            "integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
+            "dev": true,
+            "optional": true
         },
         "@discordjs/builders": {
             "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3272 +1,3272 @@
 {
-    "name": "mc-niibot",
-    "version": "1.5.0",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "mc-niibot",
-            "version": "1.5.0",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/node": "^10.26.0",
-                "atob": "^2.1.2",
-                "discord.js": "^14.6.0",
-                "dotenv": "^16.0.0",
-                "json-bigint": "^1.0.0",
-                "request": "^2.88.2"
-            },
-            "devDependencies": {
-                "@biomejs/biome": "^2.3.6"
-            }
-        },
-        "node_modules/@apm-js-collab/code-transformer": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
-            "integrity": "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@apm-js-collab/tracing-hooks": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
-            "integrity": "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@apm-js-collab/code-transformer": "^0.8.0",
-                "debug": "^4.4.1",
-                "module-details-from-path": "^1.0.4"
-            }
-        },
-        "node_modules/@biomejs/biome": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
-            "integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "bin": {
-                "biome": "bin/biome"
-            },
-            "engines": {
-                "node": ">=14.21.3"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/biome"
-            },
-            "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.3.6",
-                "@biomejs/cli-darwin-x64": "2.3.6",
-                "@biomejs/cli-linux-arm64": "2.3.6",
-                "@biomejs/cli-linux-arm64-musl": "2.3.6",
-                "@biomejs/cli-linux-x64": "2.3.6",
-                "@biomejs/cli-linux-x64-musl": "2.3.6",
-                "@biomejs/cli-win32-arm64": "2.3.6",
-                "@biomejs/cli-win32-x64": "2.3.6"
-            }
-        },
-        "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
-            "integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
-            "integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
-            "integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
-            "integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
-            "integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
-            "integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
-            "integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
-            "integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=14.21.3"
-            }
-        },
-        "node_modules/@discordjs/builders": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
-            "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
-            "dependencies": {
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/shapeshift": "^3.7.0",
-                "discord-api-types": "^0.37.12",
-                "fast-deep-equal": "^3.1.3",
-                "ts-mixer": "^6.0.1",
-                "tslib": "^2.4.0"
-            },
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/@discordjs/collection": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
-            "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw==",
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/@discordjs/rest": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
-            "integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
-            "dependencies": {
-                "@discordjs/collection": "^1.2.0",
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/async-queue": "^1.5.0",
-                "@sapphire/snowflake": "^3.2.2",
-                "discord-api-types": "^0.37.12",
-                "file-type": "^18.0.0",
-                "tslib": "^2.4.0",
-                "undici": "^5.11.0"
-            },
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/@discordjs/util": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-            "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/api-logs": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
-            "integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
-            "integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/core": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
-            "integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.204.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-amqplib": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.51.0.tgz",
-            "integrity": "sha512-XGmjYwjVRktD4agFnWBWQXo9SiYHKBxR6Ag3MLXwtLE4R99N3a08kGKM5SC1qOFKIELcQDGFEFT9ydXMH00Luw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-connect": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.48.0.tgz",
-            "integrity": "sha512-OMjc3SFL4pC16PeK+tDhwP7MRvDPalYCGSvGqUhX5rASkI2H0RuxZHOWElYeXkV0WP+70Gw6JHWac/2Zqwmhdw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/connect": "3.4.38"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-dataloader": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.22.0.tgz",
-            "integrity": "sha512-bXnTcwtngQsI1CvodFkTemrrRSQjAjZxqHVc+CJZTDnidT0T6wt3jkKhnsjU/Kkkc0lacr6VdRpCu2CUWa0OKw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-express": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.53.0.tgz",
-            "integrity": "sha512-r/PBafQmFYRjuxLYEHJ3ze1iBnP2GDA1nXOSS6E02KnYNZAVjj6WcDA1MSthtdAUUK0XnotHvvWM8/qz7DMO5A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-fs": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.24.0.tgz",
-            "integrity": "sha512-HjIxJ6CBRD770KNVaTdMXIv29Sjz4C1kPCCK5x1Ujpc6SNnLGPqUVyJYZ3LUhhnHAqdbrl83ogVWjCgeT4Q0yw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-generic-pool": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.48.0.tgz",
-            "integrity": "sha512-TLv/On8pufynNR+pUbpkyvuESVASZZKMlqCm4bBImTpXKTpqXaJJ3o/MUDeMlM91rpen+PEv2SeyOKcHCSlgag==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-graphql": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.52.0.tgz",
-            "integrity": "sha512-3fEJ8jOOMwopvldY16KuzHbRhPk8wSsOTSF0v2psmOCGewh6ad+ZbkTx/xyUK9rUdUMWAxRVU0tFpj4Wx1vkPA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-hapi": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.51.0.tgz",
-            "integrity": "sha512-qyf27DaFNL1Qhbo/da+04MSCw982B02FhuOS5/UF+PMhM61CcOiu7fPuXj8TvbqyReQuJFljXE6UirlvoT/62g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.204.0.tgz",
-            "integrity": "sha512-1afJYyGRA4OmHTv0FfNTrTAzoEjPQUYgd+8ih/lX0LlZBnGio/O80vxA0lN3knsJPS7FiDrsDrWq25K7oAzbkw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.1.0",
-                "@opentelemetry/instrumentation": "0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0",
-                "forwarded-parse": "2.1.2"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
-            "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-ioredis": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.52.0.tgz",
-            "integrity": "sha512-rUvlyZwI90HRQPYicxpDGhT8setMrlHKokCtBtZgYxQWRF5RBbG4q0pGtbZvd7kyseuHbFpA3I/5z7M8b/5ywg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/redis-common": "^0.38.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-kafkajs": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.14.0.tgz",
-            "integrity": "sha512-kbB5yXS47dTIdO/lfbbXlzhvHFturbux4EpP0+6H78Lk0Bn4QXiZQW7rmZY1xBCY16mNcCb8Yt0mhz85hTnSVA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.30.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-knex": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.49.0.tgz",
-            "integrity": "sha512-NKsRRT27fbIYL4Ix+BjjP8h4YveyKc+2gD6DMZbr5R5rUeDqfC8+DTfIt3c3ex3BIc5Vvek4rqHnN7q34ZetLQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.33.1"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-koa": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.52.0.tgz",
-            "integrity": "sha512-JJSBYLDx/mNSy8Ibi/uQixu2rH0bZODJa8/cz04hEhRaiZQoeJ5UrOhO/mS87IdgVsHrnBOsZ6vDu09znupyuA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.49.0.tgz",
-            "integrity": "sha512-ctXu+O/1HSadAxtjoEg2w307Z5iPyLOMM8IRNwjaKrIpNAthYGSOanChbk1kqY6zU5CrpkPHGdAT6jk8dXiMqw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongodb": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.57.0.tgz",
-            "integrity": "sha512-KD6Rg0KSHWDkik+qjIOWoksi1xqSpix8TSPfquIK1DTmd9OTFb5PHmMkzJe16TAPVEuElUW8gvgP59cacFcrMQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongoose": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.51.0.tgz",
-            "integrity": "sha512-gwWaAlhhV2By7XcbyU3DOLMvzsgeaymwP/jktDC+/uPkCmgB61zurwqOQdeiRq9KAf22Y2dtE5ZLXxytJRbEVA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql": {
-            "version": "0.50.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.50.0.tgz",
-            "integrity": "sha512-duKAvMRI3vq6u9JwzIipY9zHfikN20bX05sL7GjDeLKr2qV0LQ4ADtKST7KStdGcQ+MTN5wghWbbVdLgNcB3rA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/mysql": "2.15.27"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql2": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.51.0.tgz",
-            "integrity": "sha512-zT2Wg22Xn43RyfU3NOUmnFtb5zlDI0fKcijCj9AcK9zuLZ4ModgtLXOyBJSSfO+hsOCZSC1v/Fxwj+nZJFdzLQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@opentelemetry/sql-common": "^0.41.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-pg": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.57.0.tgz",
-            "integrity": "sha512-dWLGE+r5lBgm2A8SaaSYDE3OKJ/kwwy5WLyGyzor8PLhUL9VnJRiY6qhp4njwhnljiLtzeffRtG2Mf/YyWLeTw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.34.0",
-                "@opentelemetry/sql-common": "^0.41.0",
-                "@types/pg": "8.15.5",
-                "@types/pg-pool": "2.0.6"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-redis": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.53.0.tgz",
-            "integrity": "sha512-WUHV8fr+8yo5RmzyU7D5BIE1zwiaNQcTyZPwtxlfr7px6NYYx7IIpSihJK7WA60npWynfxxK1T67RAVF0Gdfjg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/redis-common": "^0.38.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-tedious": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.23.0.tgz",
-            "integrity": "sha512-3TMTk/9VtlRonVTaU4tCzbg4YqW+Iq/l5VnN2e5whP6JgEg/PKfrGbqQ+CxQWNLfLaQYIUgEZqAn5gk/inh1uQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/tedious": "^4.0.14"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-undici": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.15.0.tgz",
-            "integrity": "sha512-sNFGA/iCDlVkNjzTzPRcudmI11vT/WAfAguRdZY9IspCw02N4WSC72zTuQhSMheh2a1gdeM9my1imnKRvEEvEg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.7.0"
-            }
-        },
-        "node_modules/@opentelemetry/redis-common": {
-            "version": "0.38.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-            "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            }
-        },
-        "node_modules/@opentelemetry/resources": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.2.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-            "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.2.0",
-                "@opentelemetry/resources": "2.2.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-            "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/sql-common": {
-            "version": "0.41.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
-            "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.1.0"
-            }
-        },
-        "node_modules/@prisma/instrumentation": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.15.0.tgz",
-            "integrity": "sha512-6TXaH6OmDkMOQvOxwLZ8XS51hU2v4A3vmE2pSijCIiGRJYyNeMcL6nMHQMyYdZRD8wl7LF3Wzc+AMPMV/9Oo7A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.8"
-            }
-        },
-        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@sapphire/async-queue": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-            "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@sapphire/shapeshift": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
-            "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "lodash.uniqwith": "^4.5.0"
-            },
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@sapphire/snowflake": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-            "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==",
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@sentry/core": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.26.0.tgz",
-            "integrity": "sha512-TjDe5QI37SLuV0q3nMOH8JcPZhv2e85FALaQMIhRILH9Ce6G7xW5GSjmH91NUVq8yc3XtiqYlz/EenEZActc4Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry/node": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.26.0.tgz",
-            "integrity": "sha512-VUwNoKYhRpnHQSj9lty1TgooO+1wcpS1V0K87HU8sZEas5gx3Ujiouk5ocPjlgbKreoYOApgOnEEIq5W/hfQcQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^2.1.0",
-                "@opentelemetry/core": "^2.1.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/instrumentation-amqplib": "0.51.0",
-                "@opentelemetry/instrumentation-connect": "0.48.0",
-                "@opentelemetry/instrumentation-dataloader": "0.22.0",
-                "@opentelemetry/instrumentation-express": "0.53.0",
-                "@opentelemetry/instrumentation-fs": "0.24.0",
-                "@opentelemetry/instrumentation-generic-pool": "0.48.0",
-                "@opentelemetry/instrumentation-graphql": "0.52.0",
-                "@opentelemetry/instrumentation-hapi": "0.51.0",
-                "@opentelemetry/instrumentation-http": "0.204.0",
-                "@opentelemetry/instrumentation-ioredis": "0.52.0",
-                "@opentelemetry/instrumentation-kafkajs": "0.14.0",
-                "@opentelemetry/instrumentation-knex": "0.49.0",
-                "@opentelemetry/instrumentation-koa": "0.52.0",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.49.0",
-                "@opentelemetry/instrumentation-mongodb": "0.57.0",
-                "@opentelemetry/instrumentation-mongoose": "0.51.0",
-                "@opentelemetry/instrumentation-mysql": "0.50.0",
-                "@opentelemetry/instrumentation-mysql2": "0.51.0",
-                "@opentelemetry/instrumentation-pg": "0.57.0",
-                "@opentelemetry/instrumentation-redis": "0.53.0",
-                "@opentelemetry/instrumentation-tedious": "0.23.0",
-                "@opentelemetry/instrumentation-undici": "0.15.0",
-                "@opentelemetry/resources": "^2.1.0",
-                "@opentelemetry/sdk-trace-base": "^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.37.0",
-                "@prisma/instrumentation": "6.15.0",
-                "@sentry/core": "10.26.0",
-                "@sentry/node-core": "10.26.0",
-                "@sentry/opentelemetry": "10.26.0",
-                "import-in-the-middle": "^1.14.2",
-                "minimatch": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry/node-core": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.26.0.tgz",
-            "integrity": "sha512-7OrHVn8XAsq9mMVMlpL18XTKQEVcLOJSo0n2M7QGKfFk/OfVtSFMcUWGqN1qhYtT9aMTr2bjtR5+BI33djnNTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@apm-js-collab/tracing-hooks": "^0.3.1",
-                "@sentry/core": "10.26.0",
-                "@sentry/opentelemetry": "10.26.0",
-                "import-in-the-middle": "^1.14.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/instrumentation": ">=0.57.1 <1",
-                "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.37.0"
-            }
-        },
-        "node_modules/@sentry/opentelemetry": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.26.0.tgz",
-            "integrity": "sha512-ASJdOwn6NwMH2ZeBrnGJI+l/xkJp1AOiQ5FWkvTqLc/vHX+r3PDMO7c+koecY+LiZxSzZF4IV8sALXfOh6UnwA==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "10.26.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.37.0"
-            }
-        },
-        "node_modules/@tokenizer/token": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-        },
-        "node_modules/@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/mysql": {
-            "version": "2.15.27",
-            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
-            "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
-        },
-        "node_modules/@types/pg": {
-            "version": "8.15.5",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
-            "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "pg-protocol": "*",
-                "pg-types": "^2.2.0"
-            }
-        },
-        "node_modules/@types/pg-pool": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
-            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg": "*"
-            }
-        },
-        "node_modules/@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-            "license": "MIT"
-        },
-        "node_modules/@types/tedious": {
-            "version": "4.0.14",
-            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/ws": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^8"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "node_modules/atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "bin": {
-                "atob": "bin/atob.js"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
-            }
-        },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-        },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
-        },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
-        "node_modules/bignumber.js": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
-            }
-        },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-        },
-        "node_modules/cjs-module-lexer": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-            "license": "MIT"
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/discord-api-types": {
-            "version": "0.37.16",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.16.tgz",
-            "integrity": "sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg=="
-        },
-        "node_modules/discord.js": {
-            "version": "14.6.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
-            "integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
-            "dependencies": {
-                "@discordjs/builders": "^1.3.0",
-                "@discordjs/collection": "^1.2.0",
-                "@discordjs/rest": "^1.3.0",
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/snowflake": "^3.2.2",
-                "@types/ws": "^8.5.3",
-                "discord-api-types": "^0.37.12",
-                "fast-deep-equal": "^3.1.3",
-                "lodash.snakecase": "^4.1.1",
-                "tslib": "^2.4.0",
-                "undici": "^5.11.0",
-                "ws": "^8.9.0"
-            },
-            "engines": {
-                "node": ">=16.9.0"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ]
-        },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "node_modules/file-type": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.0.0.tgz",
-            "integrity": "sha512-jjMwFpnW8PKofLE/4ohlhqwDk5k0NC6iy0UHAJFKoY1fQeGMN0GDdLgHQrvCbSpMwbqzoCZhRI5dETCZna5qVA==",
-            "dependencies": {
-                "readable-web-to-node-stream": "^3.0.2",
-                "strtok3": "^7.0.0",
-                "token-types": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-            }
-        },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/forwarded-parse": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
-            "license": "MIT"
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
-            }
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/import-in-the-middle": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "acorn-import-attributes": "^1.9.5",
-                "cjs-module-lexer": "^1.2.2",
-                "module-details-from-path": "^1.0.3"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-        },
-        "node_modules/isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-        },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-        },
-        "node_modules/json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "dependencies": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
-        "node_modules/lodash.snakecase": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-        },
-        "node_modules/lodash.uniqwith": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-            "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
-        },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/module-details-from-path": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-            "license": "MIT"
-        },
-        "node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT"
-        },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
-        "node_modules/peek-readable": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-            "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-        },
-        "node_modules/pg-int8": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/pg-protocol": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-            "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
-            "license": "MIT"
-        },
-        "node_modules/pg-types": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-            "license": "MIT",
-            "dependencies": {
-                "pg-int8": "1.0.1",
-                "postgres-array": "~2.0.0",
-                "postgres-bytea": "~1.0.0",
-                "postgres-date": "~1.0.4",
-                "postgres-interval": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postgres-array": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postgres-bytea": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-            "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postgres-date": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postgres-interval": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-            "license": "MIT",
-            "dependencies": {
-                "xtend": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
-        "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/readable-web-to-node-stream": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-            "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-            "dependencies": {
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/strtok3": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-            "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-            "dependencies": {
-                "@tokenizer/token": "^0.3.0",
-                "peek-readable": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/token-types": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-            "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-            "dependencies": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Borewit"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/ts-mixer": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
-            "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
-        },
-        "node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-        },
-        "node_modules/undici": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-            "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
-            "dependencies": {
-                "busboy": "^1.6.0"
-            },
-            "engines": {
-                "node": ">=12.18"
-            }
-        },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "node_modules/ws": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-            "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4"
-            }
-        }
-    },
-    "dependencies": {
-        "@apm-js-collab/code-transformer": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
-            "integrity": "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="
-        },
-        "@apm-js-collab/tracing-hooks": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
-            "integrity": "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
-            "requires": {
-                "@apm-js-collab/code-transformer": "^0.8.0",
-                "debug": "^4.4.1",
-                "module-details-from-path": "^1.0.4"
-            }
-        },
-        "@biomejs/biome": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.6.tgz",
-            "integrity": "sha512-oqUhWyU6tae0MFsr/7iLe++QWRg+6jtUhlx9/0GmCWDYFFrK366sBLamNM7D9Y+c7YSynUFKr8lpEp1r6Sk7eA==",
-            "dev": true,
-            "requires": {
-                "@biomejs/cli-darwin-arm64": "2.3.6",
-                "@biomejs/cli-darwin-x64": "2.3.6",
-                "@biomejs/cli-linux-arm64": "2.3.6",
-                "@biomejs/cli-linux-arm64-musl": "2.3.6",
-                "@biomejs/cli-linux-x64": "2.3.6",
-                "@biomejs/cli-linux-x64-musl": "2.3.6",
-                "@biomejs/cli-win32-arm64": "2.3.6",
-                "@biomejs/cli-win32-x64": "2.3.6"
-            }
-        },
-        "@biomejs/cli-darwin-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.6.tgz",
-            "integrity": "sha512-P4JWE5d8UayBxYe197QJwyW4ZHp0B+zvRIGCusOm1WbxmlhpAQA1zEqQuunHgSIzvyEEp4TVxiKGXNFZPg7r9Q==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-darwin-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.6.tgz",
-            "integrity": "sha512-I4rTebj+F/L9K93IU7yTFs8nQ6EhaCOivxduRha4w4WEZK80yoZ8OAdR1F33m4yJ/NfUuTUbP/Wjs+vKjlCoWA==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-linux-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.6.tgz",
-            "integrity": "sha512-JjYy83eVBnvuINZiqyFO7xx72v8Srh4hsgaacSBCjC22DwM6+ZvnX1/fj8/SBiLuUOfZ8YhU2pfq2Dzakeyg1A==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-linux-arm64-musl": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.6.tgz",
-            "integrity": "sha512-oK1NpIXIixbJ/4Tcx40cwiieqah6rRUtMGOHDeK2ToT7yUFVEvXUGRKqH0O4hqZ9tW8TcXNZKfgRH6xrsjVtGg==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-linux-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.6.tgz",
-            "integrity": "sha512-ZjPXzy5yN9wusIoX+8Zp4p6cL8r0NzJCXg/4r1KLVveIPXd2jKVlqZ6ZyzEq385WwU3OX5KOwQYLQsOc788waQ==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-linux-x64-musl": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.6.tgz",
-            "integrity": "sha512-QvxB8GHQeaO4FCtwJpJjCgJkbHBbWxRHUxQlod+xeaYE6gtJdSkYkuxdKAQUZEOIsec+PeaDAhW9xjzYbwmOFA==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-win32-arm64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.6.tgz",
-            "integrity": "sha512-YM7hLHpwjdt8R7+O2zS1Vo2cKgqEeptiXB1tWW1rgjN5LlpZovBVKtg7zfwfRrFx3i08aNZThYpTcowpTlczug==",
-            "dev": true,
-            "optional": true
-        },
-        "@biomejs/cli-win32-x64": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.6.tgz",
-            "integrity": "sha512-psgNEYgMAobY5h+QHRBVR9xvg2KocFuBKm6axZWB/aD12NWhQjiVFQUjV6wMXhlH4iT0Q9c3yK5JFRiDC/rzHA==",
-            "dev": true,
-            "optional": true
-        },
-        "@discordjs/builders": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
-            "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
-            "requires": {
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/shapeshift": "^3.7.0",
-                "discord-api-types": "^0.37.12",
-                "fast-deep-equal": "^3.1.3",
-                "ts-mixer": "^6.0.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "@discordjs/collection": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
-            "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw=="
-        },
-        "@discordjs/rest": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
-            "integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
-            "requires": {
-                "@discordjs/collection": "^1.2.0",
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/async-queue": "^1.5.0",
-                "@sapphire/snowflake": "^3.2.2",
-                "discord-api-types": "^0.37.12",
-                "file-type": "^18.0.0",
-                "tslib": "^2.4.0",
-                "undici": "^5.11.0"
-            }
-        },
-        "@discordjs/util": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-            "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
-        },
-        "@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
-        },
-        "@opentelemetry/api-logs": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
-            "integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
-            "requires": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "@opentelemetry/context-async-hooks": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
-            "integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
-            "requires": {}
-        },
-        "@opentelemetry/core": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-            "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-            "requires": {
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            }
-        },
-        "@opentelemetry/instrumentation": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
-            "integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
-            "requires": {
-                "@opentelemetry/api-logs": "0.204.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1"
-            }
-        },
-        "@opentelemetry/instrumentation-amqplib": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.51.0.tgz",
-            "integrity": "sha512-XGmjYwjVRktD4agFnWBWQXo9SiYHKBxR6Ag3MLXwtLE4R99N3a08kGKM5SC1qOFKIELcQDGFEFT9ydXMH00Luw==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-connect": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.48.0.tgz",
-            "integrity": "sha512-OMjc3SFL4pC16PeK+tDhwP7MRvDPalYCGSvGqUhX5rASkI2H0RuxZHOWElYeXkV0WP+70Gw6JHWac/2Zqwmhdw==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/connect": "3.4.38"
-            }
-        },
-        "@opentelemetry/instrumentation-dataloader": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.22.0.tgz",
-            "integrity": "sha512-bXnTcwtngQsI1CvodFkTemrrRSQjAjZxqHVc+CJZTDnidT0T6wt3jkKhnsjU/Kkkc0lacr6VdRpCu2CUWa0OKw==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/instrumentation-express": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.53.0.tgz",
-            "integrity": "sha512-r/PBafQmFYRjuxLYEHJ3ze1iBnP2GDA1nXOSS6E02KnYNZAVjj6WcDA1MSthtdAUUK0XnotHvvWM8/qz7DMO5A==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-fs": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.24.0.tgz",
-            "integrity": "sha512-HjIxJ6CBRD770KNVaTdMXIv29Sjz4C1kPCCK5x1Ujpc6SNnLGPqUVyJYZ3LUhhnHAqdbrl83ogVWjCgeT4Q0yw==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/instrumentation-generic-pool": {
-            "version": "0.48.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.48.0.tgz",
-            "integrity": "sha512-TLv/On8pufynNR+pUbpkyvuESVASZZKMlqCm4bBImTpXKTpqXaJJ3o/MUDeMlM91rpen+PEv2SeyOKcHCSlgag==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/instrumentation-graphql": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.52.0.tgz",
-            "integrity": "sha512-3fEJ8jOOMwopvldY16KuzHbRhPk8wSsOTSF0v2psmOCGewh6ad+ZbkTx/xyUK9rUdUMWAxRVU0tFpj4Wx1vkPA==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/instrumentation-hapi": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.51.0.tgz",
-            "integrity": "sha512-qyf27DaFNL1Qhbo/da+04MSCw982B02FhuOS5/UF+PMhM61CcOiu7fPuXj8TvbqyReQuJFljXE6UirlvoT/62g==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-http": {
-            "version": "0.204.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.204.0.tgz",
-            "integrity": "sha512-1afJYyGRA4OmHTv0FfNTrTAzoEjPQUYgd+8ih/lX0LlZBnGio/O80vxA0lN3knsJPS7FiDrsDrWq25K7oAzbkw==",
-            "requires": {
-                "@opentelemetry/core": "2.1.0",
-                "@opentelemetry/instrumentation": "0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0",
-                "forwarded-parse": "2.1.2"
-            },
-            "dependencies": {
-                "@opentelemetry/core": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
-                    "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
-                    "requires": {
-                        "@opentelemetry/semantic-conventions": "^1.29.0"
-                    }
-                }
-            }
-        },
-        "@opentelemetry/instrumentation-ioredis": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.52.0.tgz",
-            "integrity": "sha512-rUvlyZwI90HRQPYicxpDGhT8setMrlHKokCtBtZgYxQWRF5RBbG4q0pGtbZvd7kyseuHbFpA3I/5z7M8b/5ywg==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/redis-common": "^0.38.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-kafkajs": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.14.0.tgz",
-            "integrity": "sha512-kbB5yXS47dTIdO/lfbbXlzhvHFturbux4EpP0+6H78Lk0Bn4QXiZQW7rmZY1xBCY16mNcCb8Yt0mhz85hTnSVA==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.30.0"
-            }
-        },
-        "@opentelemetry/instrumentation-knex": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.49.0.tgz",
-            "integrity": "sha512-NKsRRT27fbIYL4Ix+BjjP8h4YveyKc+2gD6DMZbr5R5rUeDqfC8+DTfIt3c3ex3BIc5Vvek4rqHnN7q34ZetLQ==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.33.1"
-            }
-        },
-        "@opentelemetry/instrumentation-koa": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.52.0.tgz",
-            "integrity": "sha512-JJSBYLDx/mNSy8Ibi/uQixu2rH0bZODJa8/cz04hEhRaiZQoeJ5UrOhO/mS87IdgVsHrnBOsZ6vDu09znupyuA==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-lru-memoizer": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.49.0.tgz",
-            "integrity": "sha512-ctXu+O/1HSadAxtjoEg2w307Z5iPyLOMM8IRNwjaKrIpNAthYGSOanChbk1kqY6zU5CrpkPHGdAT6jk8dXiMqw==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/instrumentation-mongodb": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.57.0.tgz",
-            "integrity": "sha512-KD6Rg0KSHWDkik+qjIOWoksi1xqSpix8TSPfquIK1DTmd9OTFb5PHmMkzJe16TAPVEuElUW8gvgP59cacFcrMQ==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-mongoose": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.51.0.tgz",
-            "integrity": "sha512-gwWaAlhhV2By7XcbyU3DOLMvzsgeaymwP/jktDC+/uPkCmgB61zurwqOQdeiRq9KAf22Y2dtE5ZLXxytJRbEVA==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-mysql": {
-            "version": "0.50.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.50.0.tgz",
-            "integrity": "sha512-duKAvMRI3vq6u9JwzIipY9zHfikN20bX05sL7GjDeLKr2qV0LQ4ADtKST7KStdGcQ+MTN5wghWbbVdLgNcB3rA==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/mysql": "2.15.27"
-            }
-        },
-        "@opentelemetry/instrumentation-mysql2": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.51.0.tgz",
-            "integrity": "sha512-zT2Wg22Xn43RyfU3NOUmnFtb5zlDI0fKcijCj9AcK9zuLZ4ModgtLXOyBJSSfO+hsOCZSC1v/Fxwj+nZJFdzLQ==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@opentelemetry/sql-common": "^0.41.0"
-            }
-        },
-        "@opentelemetry/instrumentation-pg": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.57.0.tgz",
-            "integrity": "sha512-dWLGE+r5lBgm2A8SaaSYDE3OKJ/kwwy5WLyGyzor8PLhUL9VnJRiY6qhp4njwhnljiLtzeffRtG2Mf/YyWLeTw==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.34.0",
-                "@opentelemetry/sql-common": "^0.41.0",
-                "@types/pg": "8.15.5",
-                "@types/pg-pool": "2.0.6"
-            }
-        },
-        "@opentelemetry/instrumentation-redis": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.53.0.tgz",
-            "integrity": "sha512-WUHV8fr+8yo5RmzyU7D5BIE1zwiaNQcTyZPwtxlfr7px6NYYx7IIpSihJK7WA60npWynfxxK1T67RAVF0Gdfjg==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/redis-common": "^0.38.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            }
-        },
-        "@opentelemetry/instrumentation-tedious": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.23.0.tgz",
-            "integrity": "sha512-3TMTk/9VtlRonVTaU4tCzbg4YqW+Iq/l5VnN2e5whP6JgEg/PKfrGbqQ+CxQWNLfLaQYIUgEZqAn5gk/inh1uQ==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/tedious": "^4.0.14"
-            }
-        },
-        "@opentelemetry/instrumentation-undici": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.15.0.tgz",
-            "integrity": "sha512-sNFGA/iCDlVkNjzTzPRcudmI11vT/WAfAguRdZY9IspCw02N4WSC72zTuQhSMheh2a1gdeM9my1imnKRvEEvEg==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.204.0"
-            }
-        },
-        "@opentelemetry/redis-common": {
-            "version": "0.38.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-            "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA=="
-        },
-        "@opentelemetry/resources": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-            "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-            "requires": {
-                "@opentelemetry/core": "2.2.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            }
-        },
-        "@opentelemetry/sdk-trace-base": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-            "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-            "requires": {
-                "@opentelemetry/core": "2.2.0",
-                "@opentelemetry/resources": "2.2.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            }
-        },
-        "@opentelemetry/semantic-conventions": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-            "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg=="
-        },
-        "@opentelemetry/sql-common": {
-            "version": "0.41.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
-            "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
-            "requires": {
-                "@opentelemetry/core": "^2.0.0"
-            }
-        },
-        "@prisma/instrumentation": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.15.0.tgz",
-            "integrity": "sha512-6TXaH6OmDkMOQvOxwLZ8XS51hU2v4A3vmE2pSijCIiGRJYyNeMcL6nMHQMyYdZRD8wl7LF3Wzc+AMPMV/9Oo7A==",
-            "requires": {
-                "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
-            },
-            "dependencies": {
-                "@opentelemetry/api-logs": {
-                    "version": "0.57.2",
-                    "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-                    "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-                    "requires": {
-                        "@opentelemetry/api": "^1.3.0"
-                    }
-                },
-                "@opentelemetry/instrumentation": {
-                    "version": "0.57.2",
-                    "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-                    "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-                    "requires": {
-                        "@opentelemetry/api-logs": "0.57.2",
-                        "@types/shimmer": "^1.2.0",
-                        "import-in-the-middle": "^1.8.1",
-                        "require-in-the-middle": "^7.1.1",
-                        "semver": "^7.5.2",
-                        "shimmer": "^1.2.1"
-                    }
-                }
-            }
-        },
-        "@sapphire/async-queue": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-            "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
-        },
-        "@sapphire/shapeshift": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
-            "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
-            "requires": {
-                "fast-deep-equal": "^3.1.3",
-                "lodash.uniqwith": "^4.5.0"
-            }
-        },
-        "@sapphire/snowflake": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-            "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ=="
-        },
-        "@sentry/core": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.26.0.tgz",
-            "integrity": "sha512-TjDe5QI37SLuV0q3nMOH8JcPZhv2e85FALaQMIhRILH9Ce6G7xW5GSjmH91NUVq8yc3XtiqYlz/EenEZActc4Q=="
-        },
-        "@sentry/node": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.26.0.tgz",
-            "integrity": "sha512-VUwNoKYhRpnHQSj9lty1TgooO+1wcpS1V0K87HU8sZEas5gx3Ujiouk5ocPjlgbKreoYOApgOnEEIq5W/hfQcQ==",
-            "requires": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^2.1.0",
-                "@opentelemetry/core": "^2.1.0",
-                "@opentelemetry/instrumentation": "^0.204.0",
-                "@opentelemetry/instrumentation-amqplib": "0.51.0",
-                "@opentelemetry/instrumentation-connect": "0.48.0",
-                "@opentelemetry/instrumentation-dataloader": "0.22.0",
-                "@opentelemetry/instrumentation-express": "0.53.0",
-                "@opentelemetry/instrumentation-fs": "0.24.0",
-                "@opentelemetry/instrumentation-generic-pool": "0.48.0",
-                "@opentelemetry/instrumentation-graphql": "0.52.0",
-                "@opentelemetry/instrumentation-hapi": "0.51.0",
-                "@opentelemetry/instrumentation-http": "0.204.0",
-                "@opentelemetry/instrumentation-ioredis": "0.52.0",
-                "@opentelemetry/instrumentation-kafkajs": "0.14.0",
-                "@opentelemetry/instrumentation-knex": "0.49.0",
-                "@opentelemetry/instrumentation-koa": "0.52.0",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.49.0",
-                "@opentelemetry/instrumentation-mongodb": "0.57.0",
-                "@opentelemetry/instrumentation-mongoose": "0.51.0",
-                "@opentelemetry/instrumentation-mysql": "0.50.0",
-                "@opentelemetry/instrumentation-mysql2": "0.51.0",
-                "@opentelemetry/instrumentation-pg": "0.57.0",
-                "@opentelemetry/instrumentation-redis": "0.53.0",
-                "@opentelemetry/instrumentation-tedious": "0.23.0",
-                "@opentelemetry/instrumentation-undici": "0.15.0",
-                "@opentelemetry/resources": "^2.1.0",
-                "@opentelemetry/sdk-trace-base": "^2.1.0",
-                "@opentelemetry/semantic-conventions": "^1.37.0",
-                "@prisma/instrumentation": "6.15.0",
-                "@sentry/core": "10.26.0",
-                "@sentry/node-core": "10.26.0",
-                "@sentry/opentelemetry": "10.26.0",
-                "import-in-the-middle": "^1.14.2",
-                "minimatch": "^9.0.0"
-            }
-        },
-        "@sentry/node-core": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.26.0.tgz",
-            "integrity": "sha512-7OrHVn8XAsq9mMVMlpL18XTKQEVcLOJSo0n2M7QGKfFk/OfVtSFMcUWGqN1qhYtT9aMTr2bjtR5+BI33djnNTQ==",
-            "requires": {
-                "@apm-js-collab/tracing-hooks": "^0.3.1",
-                "@sentry/core": "10.26.0",
-                "@sentry/opentelemetry": "10.26.0",
-                "import-in-the-middle": "^1.14.2"
-            }
-        },
-        "@sentry/opentelemetry": {
-            "version": "10.26.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.26.0.tgz",
-            "integrity": "sha512-ASJdOwn6NwMH2ZeBrnGJI+l/xkJp1AOiQ5FWkvTqLc/vHX+r3PDMO7c+koecY+LiZxSzZF4IV8sALXfOh6UnwA==",
-            "requires": {
-                "@sentry/core": "10.26.0"
-            }
-        },
-        "@tokenizer/token": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-        },
-        "@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/mysql": {
-            "version": "2.15.27",
-            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
-            "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/node": {
-            "version": "18.11.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
-        },
-        "@types/pg": {
-            "version": "8.15.5",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
-            "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
-            "requires": {
-                "@types/node": "*",
-                "pg-protocol": "*",
-                "pg-types": "^2.2.0"
-            }
-        },
-        "@types/pg-pool": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
-            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
-            "requires": {
-                "@types/pg": "*"
-            }
-        },
-        "@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
-        },
-        "@types/tedious": {
-            "version": "4.0.14",
-            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/ws": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
-        },
-        "acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "requires": {}
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
-        "asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
-        },
-        "aws4": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-        },
-        "balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
-        },
-        "bignumber.js": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-            "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
-        },
-        "brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "requires": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "requires": {
-                "streamsearch": "^1.1.0"
-            }
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-        },
-        "cjs-module-lexer": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "requires": {
-                "ms": "^2.1.3"
-            }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-        },
-        "discord-api-types": {
-            "version": "0.37.16",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.16.tgz",
-            "integrity": "sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg=="
-        },
-        "discord.js": {
-            "version": "14.6.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
-            "integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
-            "requires": {
-                "@discordjs/builders": "^1.3.0",
-                "@discordjs/collection": "^1.2.0",
-                "@discordjs/rest": "^1.3.0",
-                "@discordjs/util": "^0.1.0",
-                "@sapphire/snowflake": "^3.2.2",
-                "@types/ws": "^8.5.3",
-                "discord-api-types": "^0.37.12",
-                "fast-deep-equal": "^3.1.3",
-                "lodash.snakecase": "^4.1.1",
-                "tslib": "^2.4.0",
-                "undici": "^5.11.0",
-                "ws": "^8.9.0"
-            }
-        },
-        "dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
-        },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-        },
-        "file-type": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.0.0.tgz",
-            "integrity": "sha512-jjMwFpnW8PKofLE/4ohlhqwDk5k0NC6iy0UHAJFKoY1fQeGMN0GDdLgHQrvCbSpMwbqzoCZhRI5dETCZna5qVA==",
-            "requires": {
-                "readable-web-to-node-stream": "^3.0.2",
-                "strtok3": "^7.0.0",
-                "token-types": "^5.0.1"
-            }
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-        },
-        "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "forwarded-parse": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
-        },
-        "function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
-        },
-        "har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "requires": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            }
-        },
-        "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "requires": {
-                "function-bind": "^1.1.2"
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
-        },
-        "ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "import-in-the-middle": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
-            "requires": {
-                "acorn": "^8.14.0",
-                "acorn-import-attributes": "^1.9.5",
-                "cjs-module-lexer": "^1.2.2",
-                "module-details-from-path": "^1.0.3"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "requires": {
-                "hasown": "^2.0.2"
-            }
-        },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-        },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-        },
-        "json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "requires": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
-        "json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-        },
-        "jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            }
-        },
-        "lodash.snakecase": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-        },
-        "lodash.uniqwith": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-            "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
-        },
-        "mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-        },
-        "mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "requires": {
-                "mime-db": "1.52.0"
-            }
-        },
-        "minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "requires": {
-                "brace-expansion": "^2.0.1"
-            }
-        },
-        "module-details-from-path": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
-        },
-        "ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-        },
-        "peek-readable": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-            "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
-        },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-        },
-        "pg-int8": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-        },
-        "pg-protocol": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-            "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
-        },
-        "pg-types": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-            "requires": {
-                "pg-int8": "1.0.1",
-                "postgres-array": "~2.0.0",
-                "postgres-bytea": "~1.0.0",
-                "postgres-date": "~1.0.4",
-                "postgres-interval": "^1.1.0"
-            }
-        },
-        "postgres-array": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
-        },
-        "postgres-bytea": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-            "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
-        },
-        "postgres-date": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
-        },
-        "postgres-interval": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-            "requires": {
-                "xtend": "^4.0.0"
-            }
-        },
-        "psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        },
-        "qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-        },
-        "readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            }
-        },
-        "readable-web-to-node-stream": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-            "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-            "requires": {
-                "readable-stream": "^3.6.0"
-            }
-        },
-        "request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            }
-        },
-        "require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-            "requires": {
-                "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
-            }
-        },
-        "resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-            "requires": {
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            }
-        },
-        "safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
-        },
-        "shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-        },
-        "sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
-        "streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-        },
-        "string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "requires": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "strtok3": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-            "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-            "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "peek-readable": "^5.0.0"
-            }
-        },
-        "supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-        },
-        "token-types": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-            "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-            "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            }
-        },
-        "ts-mixer": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
-            "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
-        },
-        "tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
-        },
-        "undici": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-            "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
-            "requires": {
-                "busboy": "^1.6.0"
-            }
-        },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "ws": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-            "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
-            "requires": {}
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-        }
-    }
+	"name": "mc-niibot",
+	"version": "1.5.0",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "mc-niibot",
+			"version": "1.5.0",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/node": "^10.26.0",
+				"atob": "^2.1.2",
+				"discord.js": "^14.6.0",
+				"dotenv": "^16.0.0",
+				"json-bigint": "^1.0.0",
+				"request": "^2.88.2"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "^2.3.8"
+			}
+		},
+		"node_modules/@apm-js-collab/code-transformer": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
+			"integrity": "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@apm-js-collab/tracing-hooks": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
+			"integrity": "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@apm-js-collab/code-transformer": "^0.8.0",
+				"debug": "^4.4.1",
+				"module-details-from-path": "^1.0.4"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.8.tgz",
+			"integrity": "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.3.8",
+				"@biomejs/cli-darwin-x64": "2.3.8",
+				"@biomejs/cli-linux-arm64": "2.3.8",
+				"@biomejs/cli-linux-arm64-musl": "2.3.8",
+				"@biomejs/cli-linux-x64": "2.3.8",
+				"@biomejs/cli-linux-x64-musl": "2.3.8",
+				"@biomejs/cli-win32-arm64": "2.3.8",
+				"@biomejs/cli-win32-x64": "2.3.8"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.8.tgz",
+			"integrity": "sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.8.tgz",
+			"integrity": "sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.8.tgz",
+			"integrity": "sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.8.tgz",
+			"integrity": "sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.8.tgz",
+			"integrity": "sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.8.tgz",
+			"integrity": "sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.8.tgz",
+			"integrity": "sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.8.tgz",
+			"integrity": "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@discordjs/builders": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
+			"integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
+			"dependencies": {
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/shapeshift": "^3.7.0",
+				"discord-api-types": "^0.37.12",
+				"fast-deep-equal": "^3.1.3",
+				"ts-mixer": "^6.0.1",
+				"tslib": "^2.4.0"
+			},
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/@discordjs/collection": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
+			"integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw==",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/@discordjs/rest": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
+			"integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
+			"dependencies": {
+				"@discordjs/collection": "^1.2.0",
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/async-queue": "^1.5.0",
+				"@sapphire/snowflake": "^3.2.2",
+				"discord-api-types": "^0.37.12",
+				"file-type": "^18.0.0",
+				"tslib": "^2.4.0",
+				"undici": "^5.11.0"
+			},
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/@discordjs/util": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+			"integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/api-logs": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
+			"integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/context-async-hooks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
+			"integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
+			"integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.204.0",
+				"import-in-the-middle": "^1.8.1",
+				"require-in-the-middle": "^7.1.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-amqplib": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.51.0.tgz",
+			"integrity": "sha512-XGmjYwjVRktD4agFnWBWQXo9SiYHKBxR6Ag3MLXwtLE4R99N3a08kGKM5SC1qOFKIELcQDGFEFT9ydXMH00Luw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-connect": {
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.48.0.tgz",
+			"integrity": "sha512-OMjc3SFL4pC16PeK+tDhwP7MRvDPalYCGSvGqUhX5rASkI2H0RuxZHOWElYeXkV0WP+70Gw6JHWac/2Zqwmhdw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/connect": "3.4.38"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-dataloader": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.22.0.tgz",
+			"integrity": "sha512-bXnTcwtngQsI1CvodFkTemrrRSQjAjZxqHVc+CJZTDnidT0T6wt3jkKhnsjU/Kkkc0lacr6VdRpCu2CUWa0OKw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-express": {
+			"version": "0.53.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.53.0.tgz",
+			"integrity": "sha512-r/PBafQmFYRjuxLYEHJ3ze1iBnP2GDA1nXOSS6E02KnYNZAVjj6WcDA1MSthtdAUUK0XnotHvvWM8/qz7DMO5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-fs": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.24.0.tgz",
+			"integrity": "sha512-HjIxJ6CBRD770KNVaTdMXIv29Sjz4C1kPCCK5x1Ujpc6SNnLGPqUVyJYZ3LUhhnHAqdbrl83ogVWjCgeT4Q0yw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-generic-pool": {
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.48.0.tgz",
+			"integrity": "sha512-TLv/On8pufynNR+pUbpkyvuESVASZZKMlqCm4bBImTpXKTpqXaJJ3o/MUDeMlM91rpen+PEv2SeyOKcHCSlgag==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-graphql": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.52.0.tgz",
+			"integrity": "sha512-3fEJ8jOOMwopvldY16KuzHbRhPk8wSsOTSF0v2psmOCGewh6ad+ZbkTx/xyUK9rUdUMWAxRVU0tFpj4Wx1vkPA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-hapi": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.51.0.tgz",
+			"integrity": "sha512-qyf27DaFNL1Qhbo/da+04MSCw982B02FhuOS5/UF+PMhM61CcOiu7fPuXj8TvbqyReQuJFljXE6UirlvoT/62g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-http": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.204.0.tgz",
+			"integrity": "sha512-1afJYyGRA4OmHTv0FfNTrTAzoEjPQUYgd+8ih/lX0LlZBnGio/O80vxA0lN3knsJPS7FiDrsDrWq25K7oAzbkw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.1.0",
+				"@opentelemetry/instrumentation": "0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0",
+				"forwarded-parse": "2.1.2"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+			"integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-ioredis": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.52.0.tgz",
+			"integrity": "sha512-rUvlyZwI90HRQPYicxpDGhT8setMrlHKokCtBtZgYxQWRF5RBbG4q0pGtbZvd7kyseuHbFpA3I/5z7M8b/5ywg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/redis-common": "^0.38.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-kafkajs": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.14.0.tgz",
+			"integrity": "sha512-kbB5yXS47dTIdO/lfbbXlzhvHFturbux4EpP0+6H78Lk0Bn4QXiZQW7rmZY1xBCY16mNcCb8Yt0mhz85hTnSVA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.30.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-knex": {
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.49.0.tgz",
+			"integrity": "sha512-NKsRRT27fbIYL4Ix+BjjP8h4YveyKc+2gD6DMZbr5R5rUeDqfC8+DTfIt3c3ex3BIc5Vvek4rqHnN7q34ZetLQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.33.1"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-koa": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.52.0.tgz",
+			"integrity": "sha512-JJSBYLDx/mNSy8Ibi/uQixu2rH0bZODJa8/cz04hEhRaiZQoeJ5UrOhO/mS87IdgVsHrnBOsZ6vDu09znupyuA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.49.0.tgz",
+			"integrity": "sha512-ctXu+O/1HSadAxtjoEg2w307Z5iPyLOMM8IRNwjaKrIpNAthYGSOanChbk1kqY6zU5CrpkPHGdAT6jk8dXiMqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-mongodb": {
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.57.0.tgz",
+			"integrity": "sha512-KD6Rg0KSHWDkik+qjIOWoksi1xqSpix8TSPfquIK1DTmd9OTFb5PHmMkzJe16TAPVEuElUW8gvgP59cacFcrMQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-mongoose": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.51.0.tgz",
+			"integrity": "sha512-gwWaAlhhV2By7XcbyU3DOLMvzsgeaymwP/jktDC+/uPkCmgB61zurwqOQdeiRq9KAf22Y2dtE5ZLXxytJRbEVA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-mysql": {
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.50.0.tgz",
+			"integrity": "sha512-duKAvMRI3vq6u9JwzIipY9zHfikN20bX05sL7GjDeLKr2qV0LQ4ADtKST7KStdGcQ+MTN5wghWbbVdLgNcB3rA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/mysql": "2.15.27"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-mysql2": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.51.0.tgz",
+			"integrity": "sha512-zT2Wg22Xn43RyfU3NOUmnFtb5zlDI0fKcijCj9AcK9zuLZ4ModgtLXOyBJSSfO+hsOCZSC1v/Fxwj+nZJFdzLQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@opentelemetry/sql-common": "^0.41.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-pg": {
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.57.0.tgz",
+			"integrity": "sha512-dWLGE+r5lBgm2A8SaaSYDE3OKJ/kwwy5WLyGyzor8PLhUL9VnJRiY6qhp4njwhnljiLtzeffRtG2Mf/YyWLeTw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0",
+				"@opentelemetry/sql-common": "^0.41.0",
+				"@types/pg": "8.15.5",
+				"@types/pg-pool": "2.0.6"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-redis": {
+			"version": "0.53.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.53.0.tgz",
+			"integrity": "sha512-WUHV8fr+8yo5RmzyU7D5BIE1zwiaNQcTyZPwtxlfr7px6NYYx7IIpSihJK7WA60npWynfxxK1T67RAVF0Gdfjg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/redis-common": "^0.38.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-tedious": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.23.0.tgz",
+			"integrity": "sha512-3TMTk/9VtlRonVTaU4tCzbg4YqW+Iq/l5VnN2e5whP6JgEg/PKfrGbqQ+CxQWNLfLaQYIUgEZqAn5gk/inh1uQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/tedious": "^4.0.14"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/instrumentation-undici": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.15.0.tgz",
+			"integrity": "sha512-sNFGA/iCDlVkNjzTzPRcudmI11vT/WAfAguRdZY9IspCw02N4WSC72zTuQhSMheh2a1gdeM9my1imnKRvEEvEg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.7.0"
+			}
+		},
+		"node_modules/@opentelemetry/redis-common": {
+			"version": "0.38.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+			"integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/sql-common": {
+			"version": "0.41.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+			"integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "^2.0.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.1.0"
+			}
+		},
+		"node_modules/@prisma/instrumentation": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.15.0.tgz",
+			"integrity": "sha512-6TXaH6OmDkMOQvOxwLZ8XS51hU2v4A3vmE2pSijCIiGRJYyNeMcL6nMHQMyYdZRD8wl7LF3Wzc+AMPMV/9Oo7A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.8"
+			}
+		},
+		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+			"version": "0.57.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.57.2",
+				"@types/shimmer": "^1.2.0",
+				"import-in-the-middle": "^1.8.1",
+				"require-in-the-middle": "^7.1.1",
+				"semver": "^7.5.2",
+				"shimmer": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@sapphire/async-queue": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+			"integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@sapphire/shapeshift": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
+			"integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"lodash.uniqwith": "^4.5.0"
+			},
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@sapphire/snowflake": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
+			"integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==",
+			"engines": {
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@sentry/core": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.26.0.tgz",
+			"integrity": "sha512-TjDe5QI37SLuV0q3nMOH8JcPZhv2e85FALaQMIhRILH9Ce6G7xW5GSjmH91NUVq8yc3XtiqYlz/EenEZActc4Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/node": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.26.0.tgz",
+			"integrity": "sha512-VUwNoKYhRpnHQSj9lty1TgooO+1wcpS1V0K87HU8sZEas5gx3Ujiouk5ocPjlgbKreoYOApgOnEEIq5W/hfQcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/context-async-hooks": "^2.1.0",
+				"@opentelemetry/core": "^2.1.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/instrumentation-amqplib": "0.51.0",
+				"@opentelemetry/instrumentation-connect": "0.48.0",
+				"@opentelemetry/instrumentation-dataloader": "0.22.0",
+				"@opentelemetry/instrumentation-express": "0.53.0",
+				"@opentelemetry/instrumentation-fs": "0.24.0",
+				"@opentelemetry/instrumentation-generic-pool": "0.48.0",
+				"@opentelemetry/instrumentation-graphql": "0.52.0",
+				"@opentelemetry/instrumentation-hapi": "0.51.0",
+				"@opentelemetry/instrumentation-http": "0.204.0",
+				"@opentelemetry/instrumentation-ioredis": "0.52.0",
+				"@opentelemetry/instrumentation-kafkajs": "0.14.0",
+				"@opentelemetry/instrumentation-knex": "0.49.0",
+				"@opentelemetry/instrumentation-koa": "0.52.0",
+				"@opentelemetry/instrumentation-lru-memoizer": "0.49.0",
+				"@opentelemetry/instrumentation-mongodb": "0.57.0",
+				"@opentelemetry/instrumentation-mongoose": "0.51.0",
+				"@opentelemetry/instrumentation-mysql": "0.50.0",
+				"@opentelemetry/instrumentation-mysql2": "0.51.0",
+				"@opentelemetry/instrumentation-pg": "0.57.0",
+				"@opentelemetry/instrumentation-redis": "0.53.0",
+				"@opentelemetry/instrumentation-tedious": "0.23.0",
+				"@opentelemetry/instrumentation-undici": "0.15.0",
+				"@opentelemetry/resources": "^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^2.1.0",
+				"@opentelemetry/semantic-conventions": "^1.37.0",
+				"@prisma/instrumentation": "6.15.0",
+				"@sentry/core": "10.26.0",
+				"@sentry/node-core": "10.26.0",
+				"@sentry/opentelemetry": "10.26.0",
+				"import-in-the-middle": "^1.14.2",
+				"minimatch": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/node-core": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.26.0.tgz",
+			"integrity": "sha512-7OrHVn8XAsq9mMVMlpL18XTKQEVcLOJSo0n2M7QGKfFk/OfVtSFMcUWGqN1qhYtT9aMTr2bjtR5+BI33djnNTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@apm-js-collab/tracing-hooks": "^0.3.1",
+				"@sentry/core": "10.26.0",
+				"@sentry/opentelemetry": "10.26.0",
+				"import-in-the-middle": "^1.14.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/instrumentation": ">=0.57.1 <1",
+				"@opentelemetry/resources": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/semantic-conventions": "^1.37.0"
+			}
+		},
+		"node_modules/@sentry/opentelemetry": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.26.0.tgz",
+			"integrity": "sha512-ASJdOwn6NwMH2ZeBrnGJI+l/xkJp1AOiQ5FWkvTqLc/vHX+r3PDMO7c+koecY+LiZxSzZF4IV8sALXfOh6UnwA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.26.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+				"@opentelemetry/semantic-conventions": "^1.37.0"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+		},
+		"node_modules/@types/connect": {
+			"version": "3.4.38",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/mysql": {
+			"version": "2.15.27",
+			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+			"integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "18.11.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+		},
+		"node_modules/@types/pg": {
+			"version": "8.15.5",
+			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+			"integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"pg-protocol": "*",
+				"pg-types": "^2.2.0"
+			}
+		},
+		"node_modules/@types/pg-pool": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+			"integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/pg": "*"
+			}
+		},
+		"node_modules/@types/shimmer": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/tedious": {
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+			"integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"node_modules/assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"bin": {
+				"atob": "bin/atob.js"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+			"integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"dependencies": {
+				"streamsearch": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			}
+		},
+		"node_modules/caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"license": "MIT"
+		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+		},
+		"node_modules/dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/discord-api-types": {
+			"version": "0.37.16",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.16.tgz",
+			"integrity": "sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg=="
+		},
+		"node_modules/discord.js": {
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
+			"integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
+			"dependencies": {
+				"@discordjs/builders": "^1.3.0",
+				"@discordjs/collection": "^1.2.0",
+				"@discordjs/rest": "^1.3.0",
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/snowflake": "^3.2.2",
+				"@types/ws": "^8.5.3",
+				"discord-api-types": "^0.37.12",
+				"fast-deep-equal": "^3.1.3",
+				"lodash.snakecase": "^4.1.1",
+				"tslib": "^2.4.0",
+				"undici": "^5.11.0",
+				"ws": "^8.9.0"
+			},
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+			"dependencies": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"node_modules/extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+			"engines": [
+				"node >=0.6.0"
+			]
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"node_modules/file-type": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.0.0.tgz",
+			"integrity": "sha512-jjMwFpnW8PKofLE/4ohlhqwDk5k0NC6iy0UHAJFKoY1fQeGMN0GDdLgHQrvCbSpMwbqzoCZhRI5dETCZna5qVA==",
+			"dependencies": {
+				"readable-web-to-node-stream": "^3.0.2",
+				"strtok3": "^7.0.0",
+				"token-types": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
+			}
+		},
+		"node_modules/forwarded-parse": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+			"license": "MIT"
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+			"dependencies": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"node_modules/har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"deprecated": "this library is no longer supported",
+			"dependencies": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.8",
+				"npm": ">=1.3.7"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/import-in-the-middle": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+			"integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"acorn-import-attributes": "^1.9.5",
+				"cjs-module-lexer": "^1.2.2",
+				"module-details-from-path": "^1.0.3"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+		},
+		"node_modules/isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+		},
+		"node_modules/jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
+		"node_modules/jsprim": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+		},
+		"node_modules/lodash.uniqwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+			"integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/module-details-from-path": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+			"license": "MIT"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"license": "MIT"
+		},
+		"node_modules/peek-readable": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+			"integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+		},
+		"node_modules/pg-int8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/pg-protocol": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"license": "MIT"
+		},
+		"node_modules/pg-types": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+			"license": "MIT",
+			"dependencies": {
+				"pg-int8": "1.0.1",
+				"postgres-array": "~2.0.0",
+				"postgres-bytea": "~1.0.0",
+				"postgres-date": "~1.0.4",
+				"postgres-interval": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postgres-array": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postgres-bytea": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-date": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postgres-interval": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"xtend": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/psl": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+		},
+		"node_modules/punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/readable-web-to-node-stream": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+			"dependencies": {
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+			"dependencies": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/require-in-the-middle": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3",
+				"resolve": "^1.22.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/sshpk": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+			"dependencies": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/strtok3": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+			"integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+			"integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dependencies": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/ts-mixer": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+			"integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
+		},
+		"node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+		},
+		"node_modules/undici": {
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+			"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=12.18"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
+			"integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4"
+			}
+		}
+	},
+	"dependencies": {
+		"@apm-js-collab/code-transformer": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
+			"integrity": "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="
+		},
+		"@apm-js-collab/tracing-hooks": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
+			"integrity": "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
+			"requires": {
+				"@apm-js-collab/code-transformer": "^0.8.0",
+				"debug": "^4.4.1",
+				"module-details-from-path": "^1.0.4"
+			}
+		},
+		"@biomejs/biome": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.8.tgz",
+			"integrity": "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==",
+			"dev": true,
+			"requires": {
+				"@biomejs/cli-darwin-arm64": "2.3.8",
+				"@biomejs/cli-darwin-x64": "2.3.8",
+				"@biomejs/cli-linux-arm64": "2.3.8",
+				"@biomejs/cli-linux-arm64-musl": "2.3.8",
+				"@biomejs/cli-linux-x64": "2.3.8",
+				"@biomejs/cli-linux-x64-musl": "2.3.8",
+				"@biomejs/cli-win32-arm64": "2.3.8",
+				"@biomejs/cli-win32-x64": "2.3.8"
+			}
+		},
+		"@biomejs/cli-darwin-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.8.tgz",
+			"integrity": "sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-darwin-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.8.tgz",
+			"integrity": "sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-linux-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.8.tgz",
+			"integrity": "sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-linux-arm64-musl": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.8.tgz",
+			"integrity": "sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-linux-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.8.tgz",
+			"integrity": "sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-linux-x64-musl": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.8.tgz",
+			"integrity": "sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-win32-arm64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.8.tgz",
+			"integrity": "sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==",
+			"dev": true,
+			"optional": true
+		},
+		"@biomejs/cli-win32-x64": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.8.tgz",
+			"integrity": "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==",
+			"dev": true,
+			"optional": true
+		},
+		"@discordjs/builders": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
+			"integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
+			"requires": {
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/shapeshift": "^3.7.0",
+				"discord-api-types": "^0.37.12",
+				"fast-deep-equal": "^3.1.3",
+				"ts-mixer": "^6.0.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"@discordjs/collection": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
+			"integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw=="
+		},
+		"@discordjs/rest": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.3.0.tgz",
+			"integrity": "sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==",
+			"requires": {
+				"@discordjs/collection": "^1.2.0",
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/async-queue": "^1.5.0",
+				"@sapphire/snowflake": "^3.2.2",
+				"discord-api-types": "^0.37.12",
+				"file-type": "^18.0.0",
+				"tslib": "^2.4.0",
+				"undici": "^5.11.0"
+			}
+		},
+		"@discordjs/util": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+			"integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
+		},
+		"@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+		},
+		"@opentelemetry/api-logs": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
+			"integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
+			"requires": {
+				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"@opentelemetry/context-async-hooks": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
+			"integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
+			"requires": {}
+		},
+		"@opentelemetry/core": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+			"requires": {
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			}
+		},
+		"@opentelemetry/instrumentation": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
+			"integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
+			"requires": {
+				"@opentelemetry/api-logs": "0.204.0",
+				"import-in-the-middle": "^1.8.1",
+				"require-in-the-middle": "^7.1.1"
+			}
+		},
+		"@opentelemetry/instrumentation-amqplib": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.51.0.tgz",
+			"integrity": "sha512-XGmjYwjVRktD4agFnWBWQXo9SiYHKBxR6Ag3MLXwtLE4R99N3a08kGKM5SC1qOFKIELcQDGFEFT9ydXMH00Luw==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-connect": {
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.48.0.tgz",
+			"integrity": "sha512-OMjc3SFL4pC16PeK+tDhwP7MRvDPalYCGSvGqUhX5rASkI2H0RuxZHOWElYeXkV0WP+70Gw6JHWac/2Zqwmhdw==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/connect": "3.4.38"
+			}
+		},
+		"@opentelemetry/instrumentation-dataloader": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.22.0.tgz",
+			"integrity": "sha512-bXnTcwtngQsI1CvodFkTemrrRSQjAjZxqHVc+CJZTDnidT0T6wt3jkKhnsjU/Kkkc0lacr6VdRpCu2CUWa0OKw==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/instrumentation-express": {
+			"version": "0.53.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.53.0.tgz",
+			"integrity": "sha512-r/PBafQmFYRjuxLYEHJ3ze1iBnP2GDA1nXOSS6E02KnYNZAVjj6WcDA1MSthtdAUUK0XnotHvvWM8/qz7DMO5A==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-fs": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.24.0.tgz",
+			"integrity": "sha512-HjIxJ6CBRD770KNVaTdMXIv29Sjz4C1kPCCK5x1Ujpc6SNnLGPqUVyJYZ3LUhhnHAqdbrl83ogVWjCgeT4Q0yw==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/instrumentation-generic-pool": {
+			"version": "0.48.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.48.0.tgz",
+			"integrity": "sha512-TLv/On8pufynNR+pUbpkyvuESVASZZKMlqCm4bBImTpXKTpqXaJJ3o/MUDeMlM91rpen+PEv2SeyOKcHCSlgag==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/instrumentation-graphql": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.52.0.tgz",
+			"integrity": "sha512-3fEJ8jOOMwopvldY16KuzHbRhPk8wSsOTSF0v2psmOCGewh6ad+ZbkTx/xyUK9rUdUMWAxRVU0tFpj4Wx1vkPA==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/instrumentation-hapi": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.51.0.tgz",
+			"integrity": "sha512-qyf27DaFNL1Qhbo/da+04MSCw982B02FhuOS5/UF+PMhM61CcOiu7fPuXj8TvbqyReQuJFljXE6UirlvoT/62g==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-http": {
+			"version": "0.204.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.204.0.tgz",
+			"integrity": "sha512-1afJYyGRA4OmHTv0FfNTrTAzoEjPQUYgd+8ih/lX0LlZBnGio/O80vxA0lN3knsJPS7FiDrsDrWq25K7oAzbkw==",
+			"requires": {
+				"@opentelemetry/core": "2.1.0",
+				"@opentelemetry/instrumentation": "0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0",
+				"forwarded-parse": "2.1.2"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+					"integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "^1.29.0"
+					}
+				}
+			}
+		},
+		"@opentelemetry/instrumentation-ioredis": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.52.0.tgz",
+			"integrity": "sha512-rUvlyZwI90HRQPYicxpDGhT8setMrlHKokCtBtZgYxQWRF5RBbG4q0pGtbZvd7kyseuHbFpA3I/5z7M8b/5ywg==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/redis-common": "^0.38.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-kafkajs": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.14.0.tgz",
+			"integrity": "sha512-kbB5yXS47dTIdO/lfbbXlzhvHFturbux4EpP0+6H78Lk0Bn4QXiZQW7rmZY1xBCY16mNcCb8Yt0mhz85hTnSVA==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.30.0"
+			}
+		},
+		"@opentelemetry/instrumentation-knex": {
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.49.0.tgz",
+			"integrity": "sha512-NKsRRT27fbIYL4Ix+BjjP8h4YveyKc+2gD6DMZbr5R5rUeDqfC8+DTfIt3c3ex3BIc5Vvek4rqHnN7q34ZetLQ==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.33.1"
+			}
+		},
+		"@opentelemetry/instrumentation-koa": {
+			"version": "0.52.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.52.0.tgz",
+			"integrity": "sha512-JJSBYLDx/mNSy8Ibi/uQixu2rH0bZODJa8/cz04hEhRaiZQoeJ5UrOhO/mS87IdgVsHrnBOsZ6vDu09znupyuA==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-lru-memoizer": {
+			"version": "0.49.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.49.0.tgz",
+			"integrity": "sha512-ctXu+O/1HSadAxtjoEg2w307Z5iPyLOMM8IRNwjaKrIpNAthYGSOanChbk1kqY6zU5CrpkPHGdAT6jk8dXiMqw==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/instrumentation-mongodb": {
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.57.0.tgz",
+			"integrity": "sha512-KD6Rg0KSHWDkik+qjIOWoksi1xqSpix8TSPfquIK1DTmd9OTFb5PHmMkzJe16TAPVEuElUW8gvgP59cacFcrMQ==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-mongoose": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.51.0.tgz",
+			"integrity": "sha512-gwWaAlhhV2By7XcbyU3DOLMvzsgeaymwP/jktDC+/uPkCmgB61zurwqOQdeiRq9KAf22Y2dtE5ZLXxytJRbEVA==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-mysql": {
+			"version": "0.50.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.50.0.tgz",
+			"integrity": "sha512-duKAvMRI3vq6u9JwzIipY9zHfikN20bX05sL7GjDeLKr2qV0LQ4ADtKST7KStdGcQ+MTN5wghWbbVdLgNcB3rA==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/mysql": "2.15.27"
+			}
+		},
+		"@opentelemetry/instrumentation-mysql2": {
+			"version": "0.51.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.51.0.tgz",
+			"integrity": "sha512-zT2Wg22Xn43RyfU3NOUmnFtb5zlDI0fKcijCj9AcK9zuLZ4ModgtLXOyBJSSfO+hsOCZSC1v/Fxwj+nZJFdzLQ==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@opentelemetry/sql-common": "^0.41.0"
+			}
+		},
+		"@opentelemetry/instrumentation-pg": {
+			"version": "0.57.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.57.0.tgz",
+			"integrity": "sha512-dWLGE+r5lBgm2A8SaaSYDE3OKJ/kwwy5WLyGyzor8PLhUL9VnJRiY6qhp4njwhnljiLtzeffRtG2Mf/YyWLeTw==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0",
+				"@opentelemetry/sql-common": "^0.41.0",
+				"@types/pg": "8.15.5",
+				"@types/pg-pool": "2.0.6"
+			}
+		},
+		"@opentelemetry/instrumentation-redis": {
+			"version": "0.53.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.53.0.tgz",
+			"integrity": "sha512-WUHV8fr+8yo5RmzyU7D5BIE1zwiaNQcTyZPwtxlfr7px6NYYx7IIpSihJK7WA60npWynfxxK1T67RAVF0Gdfjg==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/redis-common": "^0.38.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0"
+			}
+		},
+		"@opentelemetry/instrumentation-tedious": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.23.0.tgz",
+			"integrity": "sha512-3TMTk/9VtlRonVTaU4tCzbg4YqW+Iq/l5VnN2e5whP6JgEg/PKfrGbqQ+CxQWNLfLaQYIUgEZqAn5gk/inh1uQ==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/tedious": "^4.0.14"
+			}
+		},
+		"@opentelemetry/instrumentation-undici": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.15.0.tgz",
+			"integrity": "sha512-sNFGA/iCDlVkNjzTzPRcudmI11vT/WAfAguRdZY9IspCw02N4WSC72zTuQhSMheh2a1gdeM9my1imnKRvEEvEg==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.204.0"
+			}
+		},
+		"@opentelemetry/redis-common": {
+			"version": "0.38.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+			"integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA=="
+		},
+		"@opentelemetry/resources": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+			"requires": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			}
+		},
+		"@opentelemetry/sdk-trace-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+			"requires": {
+				"@opentelemetry/core": "2.2.0",
+				"@opentelemetry/resources": "2.2.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			}
+		},
+		"@opentelemetry/semantic-conventions": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
+			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg=="
+		},
+		"@opentelemetry/sql-common": {
+			"version": "0.41.2",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+			"integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+			"requires": {
+				"@opentelemetry/core": "^2.0.0"
+			}
+		},
+		"@prisma/instrumentation": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.15.0.tgz",
+			"integrity": "sha512-6TXaH6OmDkMOQvOxwLZ8XS51hU2v4A3vmE2pSijCIiGRJYyNeMcL6nMHQMyYdZRD8wl7LF3Wzc+AMPMV/9Oo7A==",
+			"requires": {
+				"@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+			},
+			"dependencies": {
+				"@opentelemetry/api-logs": {
+					"version": "0.57.2",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+					"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+					"requires": {
+						"@opentelemetry/api": "^1.3.0"
+					}
+				},
+				"@opentelemetry/instrumentation": {
+					"version": "0.57.2",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+					"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+					"requires": {
+						"@opentelemetry/api-logs": "0.57.2",
+						"@types/shimmer": "^1.2.0",
+						"import-in-the-middle": "^1.8.1",
+						"require-in-the-middle": "^7.1.1",
+						"semver": "^7.5.2",
+						"shimmer": "^1.2.1"
+					}
+				}
+			}
+		},
+		"@sapphire/async-queue": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+			"integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
+		},
+		"@sapphire/shapeshift": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
+			"integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
+			"requires": {
+				"fast-deep-equal": "^3.1.3",
+				"lodash.uniqwith": "^4.5.0"
+			}
+		},
+		"@sapphire/snowflake": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
+			"integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ=="
+		},
+		"@sentry/core": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.26.0.tgz",
+			"integrity": "sha512-TjDe5QI37SLuV0q3nMOH8JcPZhv2e85FALaQMIhRILH9Ce6G7xW5GSjmH91NUVq8yc3XtiqYlz/EenEZActc4Q=="
+		},
+		"@sentry/node": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.26.0.tgz",
+			"integrity": "sha512-VUwNoKYhRpnHQSj9lty1TgooO+1wcpS1V0K87HU8sZEas5gx3Ujiouk5ocPjlgbKreoYOApgOnEEIq5W/hfQcQ==",
+			"requires": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/context-async-hooks": "^2.1.0",
+				"@opentelemetry/core": "^2.1.0",
+				"@opentelemetry/instrumentation": "^0.204.0",
+				"@opentelemetry/instrumentation-amqplib": "0.51.0",
+				"@opentelemetry/instrumentation-connect": "0.48.0",
+				"@opentelemetry/instrumentation-dataloader": "0.22.0",
+				"@opentelemetry/instrumentation-express": "0.53.0",
+				"@opentelemetry/instrumentation-fs": "0.24.0",
+				"@opentelemetry/instrumentation-generic-pool": "0.48.0",
+				"@opentelemetry/instrumentation-graphql": "0.52.0",
+				"@opentelemetry/instrumentation-hapi": "0.51.0",
+				"@opentelemetry/instrumentation-http": "0.204.0",
+				"@opentelemetry/instrumentation-ioredis": "0.52.0",
+				"@opentelemetry/instrumentation-kafkajs": "0.14.0",
+				"@opentelemetry/instrumentation-knex": "0.49.0",
+				"@opentelemetry/instrumentation-koa": "0.52.0",
+				"@opentelemetry/instrumentation-lru-memoizer": "0.49.0",
+				"@opentelemetry/instrumentation-mongodb": "0.57.0",
+				"@opentelemetry/instrumentation-mongoose": "0.51.0",
+				"@opentelemetry/instrumentation-mysql": "0.50.0",
+				"@opentelemetry/instrumentation-mysql2": "0.51.0",
+				"@opentelemetry/instrumentation-pg": "0.57.0",
+				"@opentelemetry/instrumentation-redis": "0.53.0",
+				"@opentelemetry/instrumentation-tedious": "0.23.0",
+				"@opentelemetry/instrumentation-undici": "0.15.0",
+				"@opentelemetry/resources": "^2.1.0",
+				"@opentelemetry/sdk-trace-base": "^2.1.0",
+				"@opentelemetry/semantic-conventions": "^1.37.0",
+				"@prisma/instrumentation": "6.15.0",
+				"@sentry/core": "10.26.0",
+				"@sentry/node-core": "10.26.0",
+				"@sentry/opentelemetry": "10.26.0",
+				"import-in-the-middle": "^1.14.2",
+				"minimatch": "^9.0.0"
+			}
+		},
+		"@sentry/node-core": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.26.0.tgz",
+			"integrity": "sha512-7OrHVn8XAsq9mMVMlpL18XTKQEVcLOJSo0n2M7QGKfFk/OfVtSFMcUWGqN1qhYtT9aMTr2bjtR5+BI33djnNTQ==",
+			"requires": {
+				"@apm-js-collab/tracing-hooks": "^0.3.1",
+				"@sentry/core": "10.26.0",
+				"@sentry/opentelemetry": "10.26.0",
+				"import-in-the-middle": "^1.14.2"
+			}
+		},
+		"@sentry/opentelemetry": {
+			"version": "10.26.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.26.0.tgz",
+			"integrity": "sha512-ASJdOwn6NwMH2ZeBrnGJI+l/xkJp1AOiQ5FWkvTqLc/vHX+r3PDMO7c+koecY+LiZxSzZF4IV8sALXfOh6UnwA==",
+			"requires": {
+				"@sentry/core": "10.26.0"
+			}
+		},
+		"@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+		},
+		"@types/connect": {
+			"version": "3.4.38",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/mysql": {
+			"version": "2.15.27",
+			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+			"integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "18.11.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+		},
+		"@types/pg": {
+			"version": "8.15.5",
+			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+			"integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+			"requires": {
+				"@types/node": "*",
+				"pg-protocol": "*",
+				"pg-types": "^2.2.0"
+			}
+		},
+		"@types/pg-pool": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+			"integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+			"requires": {
+				"@types/pg": "*"
+			}
+		},
+		"@types/shimmer": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+		},
+		"@types/tedious": {
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+			"integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+		},
+		"acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+			"requires": {}
+		},
+		"ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+		},
+		"aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"bignumber.js": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+			"integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
+		},
+		"brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"requires": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"busboy": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+			"requires": {
+				"streamsearch": "^1.1.0"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+		},
+		"cjs-module-lexer": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"requires": {
+				"ms": "^2.1.3"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+		},
+		"discord-api-types": {
+			"version": "0.37.16",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.16.tgz",
+			"integrity": "sha512-H0FDY6+ww4YZe1+L+2ERWU3KsVSInWLvK0TeImhiTi49DXff8sFLnqqnEiEdMEhwFlkQMUIe4xL5Py046s+Ksg=="
+		},
+		"discord.js": {
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.6.0.tgz",
+			"integrity": "sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==",
+			"requires": {
+				"@discordjs/builders": "^1.3.0",
+				"@discordjs/collection": "^1.2.0",
+				"@discordjs/rest": "^1.3.0",
+				"@discordjs/util": "^0.1.0",
+				"@sapphire/snowflake": "^3.2.2",
+				"@types/ws": "^8.5.3",
+				"discord-api-types": "^0.37.12",
+				"fast-deep-equal": "^3.1.3",
+				"lodash.snakecase": "^4.1.1",
+				"tslib": "^2.4.0",
+				"undici": "^5.11.0",
+				"ws": "^8.9.0"
+			}
+		},
+		"dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"file-type": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.0.0.tgz",
+			"integrity": "sha512-jjMwFpnW8PKofLE/4ohlhqwDk5k0NC6iy0UHAJFKoY1fQeGMN0GDdLgHQrvCbSpMwbqzoCZhRI5dETCZna5qVA==",
+			"requires": {
+				"readable-web-to-node-stream": "^3.0.2",
+				"strtok3": "^7.0.0",
+				"token-types": "^5.0.1"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"forwarded-parse": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
+		},
+		"function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+		},
+		"har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"requires": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
+		"import-in-the-middle": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+			"integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+			"requires": {
+				"acorn": "^8.14.0",
+				"acorn-import-attributes": "^1.9.5",
+				"cjs-module-lexer": "^1.2.2",
+				"module-details-from-path": "^1.0.3"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"requires": {
+				"hasown": "^2.0.2"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+		},
+		"json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"requires": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
+		"jsprim": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+			"integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			}
+		},
+		"lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+		},
+		"lodash.uniqwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+			"integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
+		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
+		"minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"requires": {
+				"brace-expansion": "^2.0.1"
+			}
+		},
+		"module-details-from-path": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
+		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+		},
+		"peek-readable": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+			"integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+		},
+		"pg-int8": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+		},
+		"pg-protocol": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
+		},
+		"pg-types": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+			"requires": {
+				"pg-int8": "1.0.1",
+				"postgres-array": "~2.0.0",
+				"postgres-bytea": "~1.0.0",
+				"postgres-date": "~1.0.4",
+				"postgres-interval": "^1.1.0"
+			}
+		},
+		"postgres-array": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+		},
+		"postgres-bytea": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+			"integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+		},
+		"postgres-date": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+		},
+		"postgres-interval": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+			"requires": {
+				"xtend": "^4.0.0"
+			}
+		},
+		"psl": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
+		"qs": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"readable-web-to-node-stream": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+			"requires": {
+				"readable-stream": "^3.6.0"
+			}
+		},
+		"request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			}
+		},
+		"require-in-the-middle": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"requires": {
+				"debug": "^4.3.5",
+				"module-details-from-path": "^1.0.3",
+				"resolve": "^1.22.8"
+			}
+		},
+		"resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"requires": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
+		},
+		"shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+		},
+		"sshpk": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+			"integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"streamsearch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"strtok3": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+			"integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+			"requires": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^5.0.0"
+			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+		},
+		"token-types": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+			"integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+			"requires": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"ts-mixer": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
+			"integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
+		},
+		"tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+		},
+		"undici": {
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+			"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+			"requires": {
+				"busboy": "^1.6.0"
+			}
+		},
+		"uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"ws": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
+			"integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+			"requires": {}
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,22 @@
 {
-    "name": "mc-niibot",
-    "version": "1.5.0",
-    "description": "bot for discord",
-    "main": "index.js",
-    "author": "McNiiby",
-    "license": "MIT",
-    "dependencies": {
-        "@sentry/node": "^10.26.0",
-        "atob": "^2.1.2",
-        "discord.js": "^14.6.0",
-        "dotenv": "^16.0.0",
-        "json-bigint": "^1.0.0",
-        "request": "^2.88.2"
-    }
+	"name": "mc-niibot",
+	"version": "1.5.0",
+	"description": "bot for discord",
+	"main": "index.js",
+	"author": "McNiiby",
+	"license": "MIT",
+	"scripts": {
+		"biome": "npx @biomejs/biome check . --write"
+	},
+	"dependencies": {
+		"@sentry/node": "^10.26.0",
+		"atob": "^2.1.2",
+		"discord.js": "^14.6.0",
+		"dotenv": "^16.0.0",
+		"json-bigint": "^1.0.0",
+		"request": "^2.88.2"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.6"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
 		"request": "^2.88.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.6"
+		"@biomejs/biome": "^2.3.8"
 	}
 }


### PR DESCRIPTION
## What's this about?

Added [Biome](https://biomejs.dev/) as a linter/formatter to keep the codebase clean and consistent. It's like ESLint + Prettier but faster and simpler to configure.

## Changes

**Setup:**
- Added `biome.json` config with tabs, single quotes, and recommended lint rules
- Added `npm run biome` script to check/fix the codebase
- Added CI workflow that runs Biome on PRs and pushes to main
- Updated README with code quality section

**Code cleanup:**
- Fixed a precision loss bug with a Discord channel ID that was too large for JS numbers (now uses string comparison)
- Replaced `var` with `let`/`const` throughout the codebase  
- Removed a bunch of unused imports and variables that were copy-pasted across command files
- Switched `==` to `===` for stricter equality checks
- Updated Node.js imports to use the `node:` prefix (`node:fs`, `node:path`, etc.)
- General formatting cleanup (consistent indentation, quotes, etc.)

The bot functionality is unchanged - this is purely cleanup to make the code easier to maintain.