### PR TITLE
Switch from tsc build to tsx runtime (ESM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Biome
         run: biome ci .
 
-  build:
+  typecheck:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,5 +38,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build project
-        run: npm run build
+      - name: Run TypeScript type check
+        run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,23 @@ jobs:
 
       - name: Run Biome
         run: biome ci .
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0              # we need full history to push

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # McNiibot: Clicker Heroes Discord Bot
 
-A Discord.js bot designed for the Clicker Heroes Discord server. It provides a wide array of game-specific information, moderation assistance, and automated role assignments based on player progress. The core functionality and event handling are managed in `index.js`.
+A Discord.js bot designed for the Clicker Heroes Discord server. It provides a wide array of game-specific information, moderation assistance, and automated role assignments based on player progress.
 
 ## 👾 Features
 
 -   **Extensive Game Information:** Over 80 slash commands providing detailed information about Clicker Heroes 1 mechanics, ancients, outsiders, strategies, and more (e.g., `/active`, `/ancients`, `/as`, `/firsttrans`, `/hybrid`, `/idle`, `/merc`, `/outsiders`, `/rubies`, `/skills`, `/timelapse`, `/trans`).
--   **Utility Commands:** Includes `/calclist` for links to useful calculators, `/faq`, `/glossary`, and an `/image` command with autocomplete for posting catered images. All commands can be found in the `/commands` folder.
+-   **Utility Commands:** Includes `/calclist` for links to useful calculators, `/faq`, `/glossary`, and an `/image` command with autocomplete for posting catered images.
 -   **Moderation & Auto-Moderation:** Features basic moderation tools and robust auto-moderation capabilities, including anti-spam, detection of scam links (e.g., fake Nitro), filtering of racist comments, and restrictions on posting external Discord links by new members.
 -   **Automated Role Assignment:** Assigns Discord roles to users based on their in-game progress. Players can DM the bot their `.txt` save file, which the bot processes to determine the highest hero unlocked and assign a corresponding role.
 -   **Automated Responses:** Provides quick answers to common questions and phrases within the community.
@@ -27,16 +27,19 @@ cp .env.example .env
 ```
 
 Then edit the `.env` file and replace the placeholder values with your actual:
-*   `DISCORD_TOKEN`: Your Discord bot token.
-*   `DISCORD_CLIENT_ID`: Your bot's client ID.
-*   `DISCORD_GUILD_ID`: The ID of the Discord server (guild) where the bot will operate.
+
+-  `DISCORD_TOKEN`: Your Discord bot token.
+-  `DISCORD_CLIENT_ID`: Your bot's client ID.
+-  `DISCORD_GUILD_ID`: The ID of the Discord server (guild) where the bot will operate.
+-  `SENTRY_DSN` (optional): Your Sentry DSN for error tracking.
 
 > If you are developing locally, you may want to use a dedicated test server and its ID for `DISCORD_GUILD_ID`.
 
-### 3. Start the Bot
+### 3. Build and Start the Bot
 
 ```bash
-node index.js
+npm run build
+npm start
 ```
 
 If the configuration is correct, the bot should appear online in Discord, and its slash commands will be registered/updated for the specified guild.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,19 @@ Then edit the `.env` file and replace the placeholder values with your actual:
 
 > If you are developing locally, you may want to use a dedicated test server and its ID for `DISCORD_GUILD_ID`.
 
-### 3. Build and Start the Bot
+### 3. Start the Bot
 
 ```bash
-npm run build
 npm start
 ```
 
 If the configuration is correct, the bot should appear online in Discord, and its slash commands will be registered/updated for the specified guild.
+
+To type-check without running:
+
+```bash
+npm run typecheck
+```
 
 ## 🧹 Code Quality
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.8",
 				"@types/node": "^22.0.0",
+				"tsx": "^4.0.0",
 				"typescript": "^5.0.0"
 			}
 		},
@@ -247,6 +248,448 @@
 			"integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
 			"engines": {
 				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@opentelemetry/api": {
@@ -1118,6 +1561,48 @@
 				"url": "https://dotenvx.com"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1145,6 +1630,21 @@
 			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
 			"license": "MIT"
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1152,6 +1652,19 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/hasown": {
@@ -1404,6 +1917,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1510,6 +2033,26 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
@@ -1702,6 +2245,188 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
 			"integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
+		},
+		"@esbuild/aix-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-loong64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/netbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openbsd-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/openharmony-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+			"dev": true,
+			"optional": true
 		},
 		"@opentelemetry/api": {
 			"version": "1.9.0",
@@ -2257,6 +2982,40 @@
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
 			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
 		},
+		"esbuild": {
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+			"dev": true,
+			"requires": {
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
+			}
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2277,10 +3036,26 @@
 			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
 			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
 		},
+		"fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"optional": true
+		},
 		"function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+		},
+		"get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"requires": {
+				"resolve-pkg-maps": "^1.0.0"
+			}
 		},
 		"hasown": {
 			"version": "2.0.2",
@@ -2440,6 +3215,12 @@
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
+		"resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true
+		},
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2500,6 +3281,17 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
 			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
+		"tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"requires": {
+				"esbuild": "~0.27.0",
+				"fsevents": "~2.3.3",
+				"get-tsconfig": "^4.7.5"
+			}
 		},
 		"typescript": {
 			"version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
 	"name": "mc-niibot",
 	"version": "1.5.0",
 	"description": "bot for discord",
-	"main": "dist/index.js",
+	"type": "module",
 	"author": "McNiiby",
 	"license": "MIT",
 	"scripts": {
-		"build": "tsc",
-		"start": "node dist/index.js",
+		"start": "tsx src/index.ts",
+		"typecheck": "tsc --noEmit",
 		"biome": "npx @biomejs/biome check . --write"
 	},
 	"dependencies": {
@@ -18,6 +18,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.8",
 		"@types/node": "^22.0.0",
+		"tsx": "^4.0.0",
 		"typescript": "^5.0.0"
 	}
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -7,12 +7,12 @@ import {
 	GatewayIntentBits,
 	Partials,
 } from 'discord.js';
-import { deployCommands } from './deploy-commands.js';
-import { onInteractionCreate } from './events/interactionCreate.js';
-import { onMessageCreate } from './events/messageCreate.js';
-import { onReady } from './events/ready.js';
-import { loadAll, startAutoSync } from './services/saves.js';
-import type { BotCommand } from './types/command.js';
+import { deployCommands } from './deploy-commands.ts';
+import { onInteractionCreate } from './events/interactionCreate.ts';
+import { onMessageCreate } from './events/messageCreate.ts';
+import { onReady } from './events/ready.ts';
+import { loadAll, startAutoSync } from './services/saves.ts';
+import type { BotCommand } from './types/command.ts';
 
 interface BotOptions {
 	token: string;

--- a/src/commands/2xdps.ts
+++ b/src/commands/2xdps.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/666.ts
+++ b/src/commands/666.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/active.ts
+++ b/src/commands/active.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/ancients.ts
+++ b/src/commands/ancients.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/areyouhappy.ts
+++ b/src/commands/areyouhappy.ts
@@ -1,5 +1,5 @@
 import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/as.ts
+++ b/src/commands/as.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/ascend.ts
+++ b/src/commands/ascend.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/autoclicker.ts
+++ b/src/commands/autoclicker.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/bp.ts
+++ b/src/commands/bp.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/calclist.ts
+++ b/src/commands/calclist.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/clans.ts
+++ b/src/commands/clans.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/clickmas.ts
+++ b/src/commands/clickmas.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/combo.ts
+++ b/src/commands/combo.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/consoleas.ts
+++ b/src/commands/consoleas.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/consolehybrid.ts
+++ b/src/commands/consolehybrid.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/desc.ts
+++ b/src/commands/desc.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/earlyheroes.ts
+++ b/src/commands/earlyheroes.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/edr.ts
+++ b/src/commands/edr.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/external.ts
+++ b/src/commands/external.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/fant.ts
+++ b/src/commands/fant.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/faq.ts
+++ b/src/commands/faq.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('faq').setDescription('link to FAQ'),

--- a/src/commands/fatgas.ts
+++ b/src/commands/fatgas.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/firstascension.ts
+++ b/src/commands/firstascension.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/firsttrans.ts
+++ b/src/commands/firsttrans.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/getarole.ts
+++ b/src/commands/getarole.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/gilds.ts
+++ b/src/commands/gilds.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/glossary.ts
+++ b/src/commands/glossary.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/guide.ts
+++ b/src/commands/guide.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/guido.ts
+++ b/src/commands/guido.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('guild').setDescription("It's gilds"),

--- a/src/commands/herosouls.ts
+++ b/src/commands/herosouls.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/hybrid.ts
+++ b/src/commands/hybrid.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/hybridactive.ts
+++ b/src/commands/hybridactive.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/idle.ts
+++ b/src/commands/idle.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/image.ts
+++ b/src/commands/image.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 const IMAGE_CHOICES: Record<string, string> = {
 	numberwang:

--- a/src/commands/inv.ts
+++ b/src/commands/inv.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/irisexp.ts
+++ b/src/commands/irisexp.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/lenny1.ts
+++ b/src/commands/lenny1.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/lister.ts
+++ b/src/commands/lister.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/maxancients.ts
+++ b/src/commands/maxancients.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/merc.ts
+++ b/src/commands/merc.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/morgulis.ts
+++ b/src/commands/morgulis.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/mpz.ts
+++ b/src/commands/mpz.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/oom.ts
+++ b/src/commands/oom.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/outsiders.ts
+++ b/src/commands/outsiders.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('ping').setDescription('Pong!'),

--- a/src/commands/pong.ts
+++ b/src/commands/pong.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('pong').setDescription('Ping!'),

--- a/src/commands/power5.ts
+++ b/src/commands/power5.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/pretrans.ts
+++ b/src/commands/pretrans.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/primalbug.ts
+++ b/src/commands/primalbug.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/qarush.ts
+++ b/src/commands/qarush.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/quickascension.ts
+++ b/src/commands/quickascension.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/raiddamage.ts
+++ b/src/commands/raiddamage.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/rarekappa.ts
+++ b/src/commands/rarekappa.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/rekt.ts
+++ b/src/commands/rekt.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('rekt').setDescription('rekt list'),

--- a/src/commands/relics.ts
+++ b/src/commands/relics.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/root2.ts
+++ b/src/commands/root2.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/rubies.ts
+++ b/src/commands/rubies.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/rubys.ts
+++ b/src/commands/rubys.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/sant.ts
+++ b/src/commands/sant.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/saveconvert.ts
+++ b/src/commands/saveconvert.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/scaling.ts
+++ b/src/commands/scaling.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/scinot.ts
+++ b/src/commands/scinot.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/spam.ts
+++ b/src/commands/spam.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder().setName('spam').setDescription("Don't spam"),

--- a/src/commands/tcc.ts
+++ b/src/commands/tcc.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/thanksbot.ts
+++ b/src/commands/thanksbot.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/theseancients.ts
+++ b/src/commands/theseancients.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/timelapse.ts
+++ b/src/commands/timelapse.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/tp.ts
+++ b/src/commands/tp.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/trans.ts
+++ b/src/commands/trans.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/transcending.ts
+++ b/src/commands/transcending.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/universaltruth.ts
+++ b/src/commands/universaltruth.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/useless.ts
+++ b/src/commands/useless.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/v.ts
+++ b/src/commands/v.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/whatareclans.ts
+++ b/src/commands/whatareclans.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/whereissolomon.ts
+++ b/src/commands/whereissolomon.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/commands/why.ts
+++ b/src/commands/why.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import type { BotCommand } from '../types/command.js';
+import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
 	data: new SlashCommandBuilder()

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -1,5 +1,5 @@
 import { REST, Routes } from 'discord.js';
-import type { BotCommand } from './types/command.js';
+import type { BotCommand } from './types/command.ts';
 
 /**
  * Registers slash commands with the Discord guild via the REST API.

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -2,12 +2,12 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import * as Sentry from '@sentry/node';
 import { type Message, PermissionsBitField } from 'discord.js';
-import { config } from '../config.js';
+import { config } from '../config.ts';
 import {
 	channelsPostedIn,
 	userMessageHistory,
-} from '../services/moderation.js';
-import { setRole } from '../services/roles.js';
+} from '../services/moderation.ts';
+import { setRole } from '../services/roles.ts';
 import {
 	addBannedSave,
 	addSave,
@@ -17,7 +17,7 @@ import {
 	getSaves,
 	isBannedFromRole,
 	UPLOADS_DIR,
-} from '../services/saves.js';
+} from '../services/saves.ts';
 
 const AUTO_BAN_WORDS = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
 
@@ -322,7 +322,8 @@ async function handleAutoMod(
 		userChannels[channelId] = currentTime;
 
 		if (channelKeys.length > 3) {
-			delete userChannels[channelKeys[0]];
+			const oldestKey = channelKeys[0];
+			if (oldestKey) delete userChannels[oldestKey];
 			channelKeys = Object.keys(userChannels);
 		}
 

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,5 +1,5 @@
 import type { Client, Message } from 'discord.js';
-import { isBannedFromRole } from './saves.js';
+import { isBannedFromRole } from './saves.ts';
 
 /** Maps hero slot index (1-based, as string) to Discord role ID */
 export const HERO_ROLES: Record<string, string> = {

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -8,7 +8,7 @@ import type {
 	SaveData,
 	SaveEntry,
 	SaveStore,
-} from '../types/save.js';
+} from '../types/save.ts';
 
 const ROOT = process.cwd();
 const SAVES_FILE = path.join(ROOT, 'saves.json');

--- a/src/types/discord.d.ts
+++ b/src/types/discord.d.ts
@@ -1,5 +1,5 @@
 import type { Collection } from 'discord.js';
-import type { BotCommand } from './command.js';
+import type { BotCommand } from './command.ts';
 
 declare module 'discord.js' {
 	interface Client {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,17 @@
 {
 	"compilerOptions": {
 		"target": "ES2022",
-		"module": "CommonJS",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
 		"lib": ["ES2022"],
-		"outDir": "./dist",
-		"rootDir": "./src",
+		"allowImportingTsExtensions": true,
 		"strict": true,
-		"esModuleInterop": true,
+		"noEmit": true,
+		"noUncheckedIndexedAccess": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
-		"sourceMap": true
+		"esModuleInterop": true
 	},
 	"include": ["src/**/*"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Replaces the `tsc` build step with `tsx` runtime, matching the approach used in mine-bot. No more `dist/` folder or build step needed.

## What changed

- **ESM**: Added `"type": "module"` to package.json
- **tsx**: Runs TypeScript directly, replacing `node dist/index.js` with `tsx src/index.ts`
- **tsconfig**: Switched from `CommonJS`/`outDir` to `ESNext`/`noEmit` with `allowImportingTsExtensions` and `noUncheckedIndexedAccess`
- **Import extensions**: All `.js` imports changed to `.ts` (required by ESM)
- **CI**: `build` job renamed to `typecheck`, runs `tsc --noEmit` instead of `tsc`
- **deploy.yml**: Bumped `actions/checkout` from v4 to v5
- **README**: Removed build step from setup instructions
- Fixed `noUncheckedIndexedAccess` error in channel spam detection (`channelKeys[0]` could be undefined)

## Deployment notes

The deploy script needs two updates:
- Remove `--omit=dev` from `npm install` (`tsx` is a devDependency needed at runtime)
- Change `pm2 start dist/index.js` to `pm2 start node_modules/.bin/tsx -- src/index.ts`