### PR TITLE
Add PM2 ecosystem config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ bannedFromRoles.json
 # Temporary files
 uploads/
 
+# PM2 logs
+logs/
+
 # TypeScript build output
 dist/
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,31 @@ npm run biome
 
 ## 🚢 Deployment
 
-Simply create a new release in GitHub and the website will be automatically deployed to the server.
+Simply create a new release in GitHub and the bot will be automatically deployed to the server.
 
-> [!NOTE] 
+> [!NOTE]
 > **How it works:** When you create a new Github release, a GitHub Action will merge the `main` branch into the `production` branch and Forge will deploy the changes. The deployment is handled by Laravel Forge using the `production` branch.
 
 > [!NOTE]
 > Always create releases from the `main` branch to ensure all tested changes are included in the deployment.
+
+**Deploy script used in Forge:**
+
+```bash
+cd /home/forge/mc-niibot
+
+git pull --tags origin $FORGE_SITE_BRANCH
+
+# Ensure logs directory exists
+mkdir -p logs
+
+npm install
+
+# Restart the application using PM2 ecosystem config
+pm2 reload ecosystem.config.cjs --env production || pm2 start ecosystem.config.cjs --env production
+
+pm2 save
+```
 
 ## 📂 Uploads folder
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+	apps: [
+		{
+			name: 'mc-niibot',
+			script: 'node_modules/.bin/tsx',
+			args: 'src/index.ts',
+			autorestart: true,
+			watch: false,
+			max_memory_restart: '500M',
+			restart_delay: 5000,
+			max_restarts: 10,
+			min_uptime: '10s',
+			env: {
+				NODE_ENV: 'development',
+			},
+			env_production: {
+				NODE_ENV: 'production',
+			},
+			error_file: 'logs/error.log',
+			out_file: 'logs/out.log',
+			log_file: 'logs/combined.log',
+			time: true,
+			merge_logs: true,
+			log_date_format: 'YYYY-MM-DD HH:mm:ss',
+		},
+	],
+};


### PR DESCRIPTION
Adds a PM2 ecosystem config file matching the mine-bot setup, with restart limits, memory cap, and log configuration. Also adds `logs/` to .gitignore and documents the Forge deploy script in the README.