### PR TITLE
Add traceability to save validation and fix rubies threshold

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,6 @@ export const config = {
 		/** Time window (ms) for rapid-message spam detection */
 		spamWindowMs: 8_000,
 		/** Max rubies before a save is considered cheated */
-		maxRubies: 15_000,
+		maxRubies: 5_000_000,
 	},
 } as const;

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -18,6 +18,7 @@ import {
 	isBannedFromRole,
 	UPLOADS_DIR,
 } from '../services/saves.ts';
+import { BanReason } from '../types/save.ts';
 
 const AUTO_BAN_WORDS = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];
 
@@ -88,39 +89,77 @@ async function handleDm(message: Message): Promise<void> {
 		const gameUID = saveData.uniqueId;
 
 		const saves = getSaves();
-		let userBanned = false;
+		let banReason: BanReason | null = null;
+		let matchedUserID: string | undefined;
 
 		for (const entry of saves.saves) {
 			if (!entry.gameUID) continue;
-
-			if (
-				(entry.gameUID === gameUID && entry.userID !== message.author.id) ||
-				rubies > config.moderation.maxRubies
-			) {
-				userBanned = true;
-				banFromRole(message.author.id);
-				await message.reply(
-					'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
-				);
-
-				const guild = message.client.guilds.cache.get(config.guildId);
-				const targetMember = guild?.members.cache.get(message.author.id);
-				if (targetMember) {
-					await targetMember.roles.set([]).catch(console.error);
-				}
+			if (entry.gameUID === gameUID && entry.userID !== message.author.id) {
+				matchedUserID = entry.userID;
+				banReason = BanReason.DuplicateSave;
 				break;
 			}
 		}
 
-		if (userBanned) {
+		if (rubies > config.moderation.maxRubies) {
+			banReason = BanReason.ExcessiveRubies;
+		}
+
+		if (banReason) {
+			banFromRole(message.author.id, message.author.username, banReason);
+			await message.reply(
+				'Your save was determined to be illegitimate either because you cheated or used a different users save. You will no longer be eligible for ranks on the server.',
+			);
+
+			const guild = message.client.guilds.cache.get(config.guildId);
+			const targetMember = guild?.members.cache.get(message.author.id);
+			if (targetMember) {
+				await targetMember.roles.set([]).catch(console.error);
+			}
+
+			const auditChannel = guild?.channels.cache.find(
+				(ch) => ch.name === 'audit-log',
+			);
+			if (auditChannel?.isTextBased()) {
+				let reasonText: string;
+				switch (banReason) {
+					case BanReason.ExcessiveRubies:
+						reasonText = `having ${rubies.toLocaleString()} rubies (max: ${config.moderation.maxRubies.toLocaleString()})`;
+						break;
+					case BanReason.DuplicateSave:
+						reasonText = `submitting a duplicate save (gameUID: ${gameUID})`;
+						break;
+					default: {
+						const _exhaustive: never = banReason;
+						reasonText = `unknown reason: ${_exhaustive}`;
+					}
+				}
+				await auditChannel
+					.send({
+						content: `Banned <@${message.author.id}> from role assignment for ${reasonText}.`,
+					})
+					.catch(console.error);
+			}
+
 			addBannedSave({
 				userID: message.author.id,
+				username: message.author.username,
 				gameUID,
-				userBanned,
+				rubies,
+				matchedUserID,
+				userBanned: true,
+				bannedAt: new Date().toISOString(),
+				reason: banReason,
 				save: rawData,
 			});
 		} else {
-			addSave({ userID: message.author.id, gameUID, save: rawData });
+			addSave({
+				userID: message.author.id,
+				username: message.author.username,
+				gameUID,
+				createdAt: new Date().toISOString(),
+				save: rawData,
+			});
 			await setRole(
 				highestHeroUnlocked,
 				message,

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -5,6 +5,7 @@ import type {
 	BannedFromRolesStore,
 	BannedSaveEntry,
 	BannedSaveStore,
+	BanReason,
 	SaveData,
 	SaveEntry,
 	SaveStore,
@@ -14,31 +15,64 @@ const ROOT = process.cwd();
 const SAVES_FILE = path.join(ROOT, 'saves.json');
 const BANNED_SAVES_FILE = path.join(ROOT, 'bannedSaves.json');
 const BANNED_FROM_ROLES_FILE = path.join(ROOT, 'bannedFromRoles.json');
+
+/** Directory where uploaded save files are temporarily stored before processing. */
 export const UPLOADS_DIR = path.join(ROOT, 'uploads');
 
 let saves: SaveStore = { saves: [] };
 let bannedSaves: BannedSaveStore = { saves: [] };
 let bannedFromRoles: BannedFromRolesStore = { bannedFromRoles: [] };
 
+/**
+ * Loads all JSON data stores from disk into memory. Must be called once at startup.
+ */
 export function loadAll(): void {
 	saves = JSON.parse(readFileSync(SAVES_FILE, 'utf8')) as SaveStore;
 	bannedSaves = JSON.parse(
 		readFileSync(BANNED_SAVES_FILE, 'utf8'),
 	) as BannedSaveStore;
-	bannedFromRoles = JSON.parse(
+
+	const rawBannedFromRoles = JSON.parse(
 		readFileSync(BANNED_FROM_ROLES_FILE, 'utf8'),
-	) as BannedFromRolesStore;
+	);
+	// TODO: Remove this migration after first deploy
+	if (
+		rawBannedFromRoles.bannedFromRoles.length > 0 &&
+		typeof rawBannedFromRoles.bannedFromRoles[0] === 'string'
+	) {
+		bannedFromRoles = {
+			bannedFromRoles: rawBannedFromRoles.bannedFromRoles.map(
+				(userID: string) => ({
+					userID,
+					username: null,
+					bannedAt: null,
+					reason: null,
+				}),
+			),
+		};
+	} else {
+		bannedFromRoles = rawBannedFromRoles as BannedFromRolesStore;
+	}
 
 	if (!existsSync(UPLOADS_DIR)) {
 		mkdirSync(UPLOADS_DIR);
 	}
 }
 
+/**
+ * Persists all in-memory data stores to their respective JSON files on disk.
+ */
 export function syncToDisk(): void {
 	writeFileSync(SAVES_FILE, JSON.stringify(saves));
 	writeFileSync(BANNED_SAVES_FILE, JSON.stringify(bannedSaves));
+	writeFileSync(BANNED_FROM_ROLES_FILE, JSON.stringify(bannedFromRoles));
 }
 
+/**
+ * Starts periodic auto-sync of in-memory data to disk.
+ *
+ * @param intervalMs - Sync interval in milliseconds. Defaults to 5 minutes.
+ */
 export function startAutoSync(intervalMs = 300_000): void {
 	setInterval(() => {
 		console.log('Writing save data to disk');
@@ -46,34 +80,75 @@ export function startAutoSync(intervalMs = 300_000): void {
 	}, intervalMs);
 }
 
+/**
+ * Returns the in-memory save store.
+ */
 export function getSaves(): SaveStore {
 	return saves;
 }
 
+/**
+ * Returns the in-memory banned-from-roles store.
+ */
 export function getBannedFromRoles(): BannedFromRolesStore {
 	return bannedFromRoles;
 }
 
+/**
+ * Checks whether a user is permanently banned from role assignment.
+ *
+ * @param userId - Discord user ID to check.
+ */
 export function isBannedFromRole(userId: string): boolean {
-	return bannedFromRoles.bannedFromRoles.includes(userId);
+	return bannedFromRoles.bannedFromRoles.some(
+		(entry) => entry.userID === userId,
+	);
 }
 
-export function banFromRole(userId: string): void {
-	bannedFromRoles.bannedFromRoles.push(userId);
+/**
+ * Permanently bans a user from role assignment. Writes to disk immediately.
+ *
+ * @param userId - Discord user ID to ban.
+ * @param username - Discord username at the time of the ban.
+ * @param reason - The reason for the ban.
+ */
+export function banFromRole(
+	userId: string,
+	username: string,
+	reason: BanReason,
+): void {
+	bannedFromRoles.bannedFromRoles.push({
+		userID: userId,
+		username,
+		bannedAt: new Date().toISOString(),
+		reason,
+	});
 	writeFileSync(BANNED_FROM_ROLES_FILE, JSON.stringify(bannedFromRoles));
 }
 
+/**
+ * Adds a valid save submission to the in-memory store.
+ *
+ * @param entry - The save entry to store.
+ */
 export function addSave(entry: SaveEntry): void {
 	saves.saves.push(entry);
 }
 
+/**
+ * Adds a flagged save submission to the in-memory banned saves store.
+ *
+ * @param entry - The banned save entry to store.
+ */
 export function addBannedSave(entry: BannedSaveEntry): void {
 	bannedSaves.saves.push(entry);
 }
 
 /**
- * Decodes a raw Clicker Heroes save string.
+ * Decodes a raw Clicker Heroes save string. The save format uses a magic header
+ * (`7a990` for zlib, `7e8bb` for raw deflate) followed by base64-encoded compressed JSON.
  *
+ * @param rawData - The raw save file contents.
  * @returns The parsed save object, or null if the data is invalid or decoding fails.
  */
 export function decodeSave(rawData: string): SaveData | null {
@@ -97,7 +172,9 @@ export function decodeSave(rawData: string): SaveData | null {
 }
 
 /**
- * Returns the index (1-based hero slot) of the highest hero with at least one level.
+ * Returns the 1-based hero slot index of the highest hero with at least one level.
+ *
+ * @param saveData - Decoded save data.
  */
 export function getHighestHeroUnlocked(saveData: SaveData): number {
 	const heroes = saveData.heroCollection.heroes;

--- a/src/types/save.ts
+++ b/src/types/save.ts
@@ -1,32 +1,82 @@
+/** A valid save submission stored for future duplicate detection. */
 export interface SaveEntry {
+	/** Discord user ID of the submitter. */
 	userID: string;
+	/** Discord username at the time of submission. Missing on legacy entries. */
+	username?: string;
+	/** Unique identifier from the Clicker Heroes save file. */
 	gameUID: string | undefined;
+	/** ISO 8601 timestamp of when the save was submitted. Missing on legacy entries. */
+	createdAt?: string;
+	/** Raw encoded save file contents. */
 	save: string;
 }
 
+/** Reason a save was flagged and the user was banned from role assignment. */
+export enum BanReason {
+	/** A different Discord user already submitted a save with the same game UID. */
+	DuplicateSave = 'duplicate_save',
+	/** The save's ruby count exceeds the configured maximum threshold. */
+	ExcessiveRubies = 'excessive_rubies',
+}
+
+/** A save submission that was flagged as illegitimate. */
 export interface BannedSaveEntry {
+	/** Discord user ID of the banned submitter. */
 	userID: string;
+	/** Discord username at the time of the ban. Missing on legacy entries. */
+	username?: string;
+	/** Unique identifier from the Clicker Heroes save file. */
 	gameUID: string | undefined;
-	userBanned: boolean;
+	/** Ruby count found in the save at the time of the ban. Missing on legacy entries. */
+	rubies?: number;
+	/** The user ID of the existing save owner that matched, when banned for duplicate save. Missing on legacy entries. */
+	matchedUserID?: string;
+	/** Whether the user was banned from role assignment. */
+	userBanned?: boolean;
+	/** ISO 8601 timestamp of when the ban occurred. Missing on legacy entries. */
+	bannedAt?: string;
+	/** The reason the save was flagged. Missing on legacy entries. */
+	reason?: BanReason;
+	/** Raw encoded save file contents. */
 	save: string;
 }
 
+/** Persistent store for valid save submissions. */
 export interface SaveStore {
 	saves: SaveEntry[];
 }
 
+/** Persistent store for flagged save submissions. */
 export interface BannedSaveStore {
 	saves: BannedSaveEntry[];
 }
 
-export interface BannedFromRolesStore {
-	bannedFromRoles: string[];
+/** A user permanently banned from role assignment. Nullable fields indicate legacy data from before traceability was added. */
+export interface BannedFromRolesEntry {
+	/** Discord user ID of the banned user. */
+	userID: string;
+	/** Discord username at the time of the ban, or null for legacy entries. */
+	username: string | null;
+	/** ISO 8601 timestamp of when the ban occurred, or null for legacy entries. */
+	bannedAt: string | null;
+	/** The reason for the ban, or null for legacy entries. */
+	reason: BanReason | null;
 }
 
+/** Persistent store for users permanently banned from role assignment. */
+export interface BannedFromRolesStore {
+	bannedFromRoles: BannedFromRolesEntry[];
+}
+
+/** Decoded Clicker Heroes save file data. */
 export interface SaveData {
+	/** Collection of heroes and their levels. */
 	heroCollection: {
 		heroes: Record<string, { level: number }>;
 	};
+	/** Current ruby count. */
 	rubies: number;
+	/** Unique save identifier, typically a Steam ID or generated UID. */
 	uniqueId: string;
 }


### PR DESCRIPTION
## Summary

The save validation logic that checks for cheated saves was using a `maxRubies` threshold of 15,000, which is too low - there's a rubies pack in the game that gives 14,000 rubies alone. This was causing false bans on legitimate players. The threshold has been raised to 5,000,000 after discussion with the community and Jukebox.

Additionally, the ban data stores had no traceability at all - no timestamps, no reason tracking, no usernames. When investigating the false bans, we had to manually decode save file blobs just to figure out what happened. This PR adds proper metadata to all three data stores so that future incidents can be investigated without guesswork.

## What changed

### Rubies threshold

`maxRubies` in `config.ts` changed from `15,000` to `5,000,000`.

### Ban reason tracking

A `BanReason` enum was added to distinguish between the two conditions that can trigger a ban:

```typescript
enum BanReason {
  DuplicateSave = 'duplicate_save',
  ExcessiveRubies = 'excessive_rubies',
}
```

Previously, both conditions were combined in a single `if` with `||`, making it impossible to tell which one triggered the ban. The logic has been split so each reason is tracked independently. The duplicate save check now also captures the `matchedUserID` (the owner of the original save) even if the rubies check also triggers.

### Data store schema changes

```diff
 # saves.json (SaveEntry)
  userID: string
+ username?: string
  gameUID: string | undefined
+ createdAt?: string
  save: string

 # bannedSaves.json (BannedSaveEntry)
  userID: string
+ username?: string
  gameUID: string | undefined
- userBanned: boolean
+ rubies?: number
+ matchedUserID?: string
+ userBanned?: boolean
+ bannedAt?: string
+ reason?: BanReason
  save: string

 # bannedFromRoles.json (BannedFromRolesEntry)
- bannedFromRoles: string[]
+ bannedFromRoles: {
+   userID: string
+   username: string | null
+   bannedAt: string | null
+   reason: BanReason | null
+ }[]
```

New fields are optional (`?`) on `saves.json` and `bannedSaves.json` to remain compatible with existing entries on disk. For `bannedFromRoles.json`, a one-time migration in `loadAll()` converts the old `string[]` format to the new object format automatically on startup.

### Audit log

Save bans now post a message to the `audit-log` Discord channel, similar to how the auto-moderation features already do. The message includes the specific reason and relevant details (ruby count or matched game UID).

### Docblocks

Full documentation coverage was added to `save.ts` (all interfaces, enums, and fields) and `saves.ts` (all exported functions).