### PR TITLE
Clean up ban types and add JSON file fallback

### DIFF
--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -29,10 +29,9 @@ let bannedFromRoles: BannedFromRolesStore = { bannedFromRoles: [] };
 export function loadAll(): void {
 	saves = loadJsonFile<SaveStore>(SAVES_FILE, { saves: [] });
 	bannedSaves = loadJsonFile<BannedSaveStore>(BANNED_SAVES_FILE, { saves: [] });
-	bannedFromRoles = loadJsonFile<BannedFromRolesStore>(
-		BANNED_FROM_ROLES_FILE,
-		{ bannedFromRoles: [] },
-	);
+	bannedFromRoles = loadJsonFile<BannedFromRolesStore>(BANNED_FROM_ROLES_FILE, {
+		bannedFromRoles: [],
+	});
 
 	if (!existsSync(UPLOADS_DIR)) {
 		mkdirSync(UPLOADS_DIR);

--- a/src/services/saves.ts
+++ b/src/services/saves.ts
@@ -27,36 +27,27 @@ let bannedFromRoles: BannedFromRolesStore = { bannedFromRoles: [] };
  * Loads all JSON data stores from disk into memory. Must be called once at startup.
  */
 export function loadAll(): void {
-	saves = JSON.parse(readFileSync(SAVES_FILE, 'utf8')) as SaveStore;
-	bannedSaves = JSON.parse(
-		readFileSync(BANNED_SAVES_FILE, 'utf8'),
-	) as BannedSaveStore;
-
-	const rawBannedFromRoles = JSON.parse(
-		readFileSync(BANNED_FROM_ROLES_FILE, 'utf8'),
+	saves = loadJsonFile<SaveStore>(SAVES_FILE, { saves: [] });
+	bannedSaves = loadJsonFile<BannedSaveStore>(BANNED_SAVES_FILE, { saves: [] });
+	bannedFromRoles = loadJsonFile<BannedFromRolesStore>(
+		BANNED_FROM_ROLES_FILE,
+		{ bannedFromRoles: [] },
 	);
-	// TODO: Remove this migration after first deploy
-	if (
-		rawBannedFromRoles.bannedFromRoles.length > 0 &&
-		typeof rawBannedFromRoles.bannedFromRoles[0] === 'string'
-	) {
-		bannedFromRoles = {
-			bannedFromRoles: rawBannedFromRoles.bannedFromRoles.map(
-				(userID: string) => ({
-					userID,
-					username: null,
-					bannedAt: null,
-					reason: null,
-				}),
-			),
-		};
-	} else {
-		bannedFromRoles = rawBannedFromRoles as BannedFromRolesStore;
-	}
 
 	if (!existsSync(UPLOADS_DIR)) {
 		mkdirSync(UPLOADS_DIR);
 	}
+}
+
+/**
+ * Loads a JSON file from disk, or returns a default value if the file doesn't exist.
+ */
+function loadJsonFile<T>(filePath: string, defaultValue: T): T {
+	if (!existsSync(filePath)) {
+		writeFileSync(filePath, JSON.stringify(defaultValue));
+		return defaultValue;
+	}
+	return JSON.parse(readFileSync(filePath, 'utf8')) as T;
 }
 
 /**

--- a/src/types/save.ts
+++ b/src/types/save.ts
@@ -24,20 +24,20 @@ export enum BanReason {
 export interface BannedSaveEntry {
 	/** Discord user ID of the banned submitter. */
 	userID: string;
-	/** Discord username at the time of the ban. Missing on legacy entries. */
-	username?: string;
+	/** Discord username at the time of the ban. */
+	username: string;
 	/** Unique identifier from the Clicker Heroes save file. */
 	gameUID: string | undefined;
-	/** Ruby count found in the save at the time of the ban. Missing on legacy entries. */
-	rubies?: number;
-	/** The user ID of the existing save owner that matched, when banned for duplicate save. Missing on legacy entries. */
-	matchedUserID?: string;
+	/** Ruby count found in the save at the time of the ban. */
+	rubies: number;
+	/** The user ID of the existing save owner that matched, when banned for duplicate save. */
+	matchedUserID: string | undefined;
 	/** Whether the user was banned from role assignment. */
-	userBanned?: boolean;
-	/** ISO 8601 timestamp of when the ban occurred. Missing on legacy entries. */
-	bannedAt?: string;
-	/** The reason the save was flagged. Missing on legacy entries. */
-	reason?: BanReason;
+	userBanned: boolean;
+	/** ISO 8601 timestamp of when the ban occurred. */
+	bannedAt: string;
+	/** The reason the save was flagged. */
+	reason: BanReason;
 	/** Raw encoded save file contents. */
 	save: string;
 }
@@ -52,16 +52,16 @@ export interface BannedSaveStore {
 	saves: BannedSaveEntry[];
 }
 
-/** A user permanently banned from role assignment. Nullable fields indicate legacy data from before traceability was added. */
+/** A user permanently banned from role assignment. */
 export interface BannedFromRolesEntry {
 	/** Discord user ID of the banned user. */
 	userID: string;
-	/** Discord username at the time of the ban, or null for legacy entries. */
-	username: string | null;
-	/** ISO 8601 timestamp of when the ban occurred, or null for legacy entries. */
-	bannedAt: string | null;
-	/** The reason for the ban, or null for legacy entries. */
-	reason: BanReason | null;
+	/** Discord username at the time of the ban. */
+	username: string;
+	/** ISO 8601 timestamp of when the ban occurred. */
+	bannedAt: string;
+	/** The reason for the ban. */
+	reason: BanReason;
 }
 
 /** Persistent store for users permanently banned from role assignment. */


### PR DESCRIPTION
Follow-up to #26.

**Type cleanup:**
- `BannedSaveEntry` fields (`username`, `rubies`, `matchedUserID`, `bannedAt`, `reason`) changed from optional to required
- `BannedFromRolesEntry` fields (`username`, `bannedAt`, `reason`) changed from `| null` to required
- Removed one-time migration logic from `loadAll()`

**JSON file fallback:**
- If any data file (`saves.json`, `bannedSaves.json`, `bannedFromRoles.json`) is missing on startup, the bot now creates it with an empty default instead of crashing. This means we can safely `rm` the ban files on the server and the bot will recreate them.