### PR TITLE
Replace deprecated ephemeral option with MessageFlags

### DIFF
--- a/src/commands/areyouhappy.ts
+++ b/src/commands/areyouhappy.ts
@@ -1,4 +1,8 @@
-import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import {
+	MessageFlags,
+	PermissionFlagsBits,
+	SlashCommandBuilder,
+} from 'discord.js';
 import type { BotCommand } from '../types/command.ts';
 
 export const command: BotCommand = {
@@ -19,7 +23,10 @@ export const command: BotCommand = {
 
 		if (!channel?.isSendable()) return;
 
-		await interaction.reply({ content: 'sending pings', ephemeral: true });
+		await interaction.reply({
+			content: 'sending pings',
+			flags: MessageFlags.Ephemeral,
+		});
 
 		setTimeout(() => {
 			channel.send(`${user} are`).catch(console.error);

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import type { Interaction } from 'discord.js';
+import { type Interaction, MessageFlags } from 'discord.js';
 
 export async function onInteractionCreate(
 	interaction: Interaction,
@@ -22,15 +22,15 @@ export async function onInteractionCreate(
 				extra: { command: interaction.commandName },
 			});
 
-			const reply = {
-				content: 'There was an error while executing this command!',
-				ephemeral: true,
-			};
-
+			const content = 'There was an error while executing this command!';
 			if (interaction.replied || interaction.deferred) {
-				await interaction.followUp(reply).catch(console.error);
+				await interaction
+					.followUp({ content, flags: MessageFlags.Ephemeral })
+					.catch(console.error);
 			} else {
-				await interaction.reply(reply).catch(console.error);
+				await interaction
+					.reply({ content, flags: MessageFlags.Ephemeral })
+					.catch(console.error);
 			}
 		}
 	} else if (interaction.isAutocomplete()) {


### PR DESCRIPTION
Fixes MC-NIIBOT-4.

discord.js 14.25 deprecated `{ ephemeral: true }` in interaction replies. Replaced with `{ flags: MessageFlags.Ephemeral }` in the two places it was used.