### PR TITLE
Limit image autocomplete to 25 results

### DIFF
--- a/src/commands/image.ts
+++ b/src/commands/image.ts
@@ -70,9 +70,9 @@ export const command: BotCommand = {
 
 	async autoComplete(interaction) {
 		const focusedValue = interaction.options.getFocused();
-		const filtered = Object.keys(IMAGE_CHOICES).filter((key) =>
-			key.startsWith(focusedValue),
-		);
+		const filtered = Object.keys(IMAGE_CHOICES)
+			.filter((key) => key.startsWith(focusedValue))
+			.slice(0, 25);
 
 		await interaction.respond(
 			filtered.map((key) => ({


### PR DESCRIPTION
Fixes MC-NIIBOT-3.

Discord limits autocomplete responses to 25 choices. The image command has 54 entries, so typing nothing or a single letter would return more than 25 and Discord would reject the response with `Invalid Form Body`.