### PR TITLE
Handle expired interaction errors gracefully

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/node';
 import {
 	Client,
 	Collection,
+	DiscordAPIError,
 	Events,
 	GatewayIntentBits,
 	type Interaction,
@@ -14,6 +15,7 @@ import {
 	Partials,
 	PermissionsBitField,
 } from 'discord.js';
+import { RESTJSONErrorCodes } from 'discord-api-types/v10';
 import { config } from './config.ts';
 import { deployCommands } from './deploy-commands.ts';
 import {
@@ -164,6 +166,13 @@ export class Bot {
 				Sentry.captureException(error, {
 					extra: { command: interaction.commandName },
 				});
+
+				// No point replying if the interaction already expired
+				if (
+					error instanceof DiscordAPIError &&
+					error.code === RESTJSONErrorCodes.UnknownInteraction
+				)
+					return;
 
 				const content = 'There was an error while executing this command!';
 				if (interaction.replied || interaction.deferred) {

--- a/src/services/moderation.ts
+++ b/src/services/moderation.ts
@@ -1,11 +1,13 @@
 import * as Sentry from '@sentry/node';
 import { DiscordAPIError, type Message, PermissionsBitField } from 'discord.js';
+import { RESTJSONErrorCodes } from 'discord-api-types/v10';
 import { config } from '../config.ts';
 
-/** Discord API error codes that are expected and safe to ignore in automod. */
+/** Discord API error codes that are expected and safe to ignore. */
 const IGNORED_DISCORD_ERRORS = new Set([
-	10008, // Unknown Message - already deleted
-	50278, // Cannot send messages to this user - DMs disabled
+	RESTJSONErrorCodes.UnknownMessage,
+	RESTJSONErrorCodes.UnknownInteraction,
+	RESTJSONErrorCodes.CannotSendMessagesToThisUser,
 ]);
 
 const AUTO_BAN_WORDS = ['nigger', 'nigga', 'jew', 'n1gger', 'n!gger'];


### PR DESCRIPTION
When a command fails with `DiscordAPIError[10062]` (Unknown Interaction), the error handler was trying to reply to the already-expired interaction, which would always fail and create additional Sentry noise. Now it skips the reply attempt while still reporting the original error to Sentry.

Also replaced hardcoded Discord error codes with named `RESTJSONErrorCodes` constants.

Fixes MC-NIIBOT-9, MC-NIIBOT-A, MC-NIIBOT-B