### PR TITLE
Suppress expired interaction errors from Sentry

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -162,17 +162,18 @@ export class Bot {
 			try {
 				await command.execute(interaction);
 			} catch (error) {
+				if (
+					error instanceof DiscordAPIError &&
+					error.code === RESTJSONErrorCodes.UnknownInteraction
+				) {
+					console.warn(`Expired interaction in /${interaction.commandName}`);
+					return;
+				}
+
 				console.error(error);
 				Sentry.captureException(error, {
 					extra: { command: interaction.commandName },
 				});
-
-				// No point replying if the interaction already expired
-				if (
-					error instanceof DiscordAPIError &&
-					error.code === RESTJSONErrorCodes.UnknownInteraction
-				)
-					return;
 
 				const content = 'There was an error while executing this command!';
 				if (interaction.replied || interaction.deferred) {


### PR DESCRIPTION
Expired interactions (Discord error 10062) are transient network/Discord issues, not bot bugs. PR #32 prevented the cascading reply error but still reported the original error to Sentry. This moves the check before the Sentry capture so these don't create noise.

Fixes MC-NIIBOT-F