### PR TITLE
Remove the GuildMembers privileged intent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,7 +51,6 @@ export class Bot {
 				GatewayIntentBits.Guilds,
 				GatewayIntentBits.GuildMessages,
 				GatewayIntentBits.MessageContent,
-				GatewayIntentBits.GuildMembers,
 				GatewayIntentBits.DirectMessages,
 			],
 			partials: [Partials.Channel],
@@ -309,7 +308,9 @@ export class Bot {
 				);
 
 				const guild = message.client.guilds.cache.get(config.guildId);
-				const targetMember = guild?.members.cache.get(message.author.id);
+				const targetMember = await guild?.members
+					.fetch(message.author.id)
+					.catch(() => null);
 				if (targetMember) {
 					await targetMember.roles.set([]).catch(console.error);
 				}


### PR DESCRIPTION
Discord's new privileged intent policy requires a per-intent review once an app passes 10,000 users (we got the notification, deadline is Sep 9). MessageContent is genuinely needed for the automod, but nothing here needs GuildMembers: there are no member event handlers, and all member data comes from message/interaction payloads or single-member REST fetches, none of which are gated by the intent.

The one spot that relied on it was the cheater role strip, which looked the member up in the cache. That lookup was already unreliable, since the cache only holds members seen since the last boot and save submissions arrive via DM, so it now fetches the member over REST instead.

Also sets `eol=lf` in `.gitattributes` so checkouts use LF on Windows too, matching `.editorconfig` and biome.

Deploy this before turning off the "Server Members Intent" toggle in the Developer Portal, otherwise the old process gets kicked off the gateway on reconnect. After that, only Message Content needs the review form.
